### PR TITLE
docs: add personal-fork notice to README and website

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Cross platform shell management.
 
+> **THIS IS A PERSONAL FORK.**
+> **FOR THE OFFICIAL PROJECT, GO TO [aliae.dev](https://aliae.dev) AND [JanDeDobbeleer/aliae](https://github.com/JanDeDobbeleer/aliae).**
+
 [![License][license]](LISENCE)
 
 ![Release Status][release-status]

--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -58,6 +58,17 @@ function Home() {
         <div className="container">
           <h1 className="hero__title">{siteConfig.title}</h1>
           <p className="hero__subtitle">{siteConfig.tagline}</p>
+          <p>
+            <strong>THIS IS A PERSONAL FORK.</strong>{" "}
+            <strong>
+              FOR THE OFFICIAL PROJECT, GO TO{" "}
+              <a href="https://aliae.dev">aliae.dev</a> AND{" "}
+              <a href="https://github.com/JanDeDobbeleer/aliae">
+                JanDeDobbeleer/aliae
+              </a>
+              .
+            </strong>
+          </p>
           <div className={styles.buttons}>
             <Link
               className={classnames(


### PR DESCRIPTION
## Summary
- add a prominent notice in the README that this is a personal fork
- add the same prominent notice on the website home page
- point users to the official project at `aliae.dev` and `JanDeDobbeleer/aliae`

## Validation
- `cd website && npm ci && npm run build`