### PR TITLE
docs: improve upstream notice readability on homepage

### DIFF
--- a/website/src/pages/index.js
+++ b/website/src/pages/index.js
@@ -58,31 +58,20 @@ function Home() {
         <div className="container">
           <h1 className="hero__title">{siteConfig.title}</h1>
           <p className="hero__subtitle">{siteConfig.tagline}</p>
-          <p>
-            <strong>THIS IS A PERSONAL FORK.</strong>{" "}
-            <strong>
-              FOR THE OFFICIAL PROJECT, GO TO{" "}
-              <a href="https://aliae.dev">aliae.dev</a> AND{" "}
-              <a href="https://github.com/JanDeDobbeleer/aliae">
-                JanDeDobbeleer/aliae
-              </a>
-              .
-            </strong>
-          </p>
-          <div className={styles.buttons} style={{ marginBottom: "1rem" }}>
-            <a
-              className="button button--secondary button--sm"
-              href="https://aliae.dev"
-            >
-              Official docs
+          <p className={styles.forkNotice}>
+            <strong>THIS IS A PERSONAL FORK.</strong> Use the official project at{" "}
+            <a className={styles.noticeLink} href="https://aliae.dev">
+              aliae.dev
             </a>{" "}
+            and{" "}
             <a
-              className="button button--secondary button--sm"
+              className={styles.noticeLink}
               href="https://github.com/JanDeDobbeleer/aliae"
             >
-              Official GitHub repo
+              JanDeDobbeleer/aliae
             </a>
-          </div>
+            .
+          </p>
           <div className={styles.buttons}>
             <Link
               className={classnames(

--- a/website/src/pages/styles.module.css
+++ b/website/src/pages/styles.module.css
@@ -40,3 +40,29 @@
   border-style: solid;
   border-width: 1px;
 }
+
+.forkNotice {
+  margin: 1rem auto 1.25rem;
+  max-width: 56rem;
+  padding: 0.85rem 1rem;
+  font-weight: 600;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.25);
+  border: 2px solid rgba(255, 255, 255, 0.7);
+  border-radius: 0.5rem;
+}
+
+.noticeLink {
+  display: inline-block;
+  padding: 0.05rem 0.5rem;
+  margin: 0 0.1rem;
+  color: #111;
+  background: #ffe082;
+  border-radius: 0.25rem;
+  text-decoration: none;
+  font-weight: 700;
+}
+
+.noticeLink:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
## Summary
- remove the separate upstream button row that pushed layout downward
- keep the personal-fork warning prominent in one compact notice block
- style upstream links as highlighted inline links for clear visibility

## Validation
- `cd website && npm ci && npm run build`