### PR TITLE
docs: use fork install sources and document it

### DIFF
--- a/website/docs/installation/linux.mdx
+++ b/website/docs/installation/linux.mdx
@@ -23,14 +23,16 @@ import InstallHomebrew from "./homebrew.mdx";
 Install the latest version for your system by running the following command:
 
 ```bash
-curl -s https://aliae.dev/install.sh | bash -s
+curl -s https://trajano.github.io/aliae/install.sh | bash -s
 ```
+
+> Note: this manual command installs from the `trajano/aliae` fork, not the official `JanDeDobbeleer/aliae` repository.
 
 By default the script will install to `/usr/local/bin` or the existing aliae executable's installation folder.
 If you want to install to a different location you can specify it using the `-d` flag:
 
 ```bash
-curl -s https://aliae.dev/install.sh | bash -s -- -d ~/bin
+curl -s https://trajano.github.io/aliae/install.sh | bash -s -- -d ~/bin
 ```
 
 </TabItem>

--- a/website/docs/installation/macos.mdx
+++ b/website/docs/installation/macos.mdx
@@ -28,14 +28,16 @@ import InstallHomebrew from "./homebrew.mdx";
 Install the latest version for your system by running the following command:
 
 ```bash
-curl -s https://aliae.dev/install.sh | bash -s
+curl -s https://trajano.github.io/aliae/install.sh | bash -s
 ```
+
+> Note: this manual command installs from the `trajano/aliae` fork, not the official `JanDeDobbeleer/aliae` repository.
 
 By default the script will install to `/usr/local/bin` or the existing aliae executable's installation folder.
 If you want to install to a different location you can specify it using the `-d` flag:
 
 ```bash
-curl -s https://aliae.dev/install.sh | bash -s -- -d ~/bin
+curl -s https://trajano.github.io/aliae/install.sh | bash -s -- -d ~/bin
 ```
 
 </TabItem>

--- a/website/docs/installation/windows.mdx
+++ b/website/docs/installation/windows.mdx
@@ -31,8 +31,10 @@ winget install JanDeDobbeleer.Aliae -s winget
 Open a PowerShell prompt and run the following command:
 
 ```powershell
-Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://aliae.dev/install.ps1'))
+Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://trajano.github.io/aliae/install.ps1'))
 ```
+
+> Note: this manual command installs from the `trajano/aliae` fork, not the official `JanDeDobbeleer/aliae` repository.
 
 </TabItem>
 </Tabs>
@@ -61,7 +63,7 @@ winget upgrade JanDeDobbeleer.Aliae -s winget
 Open a PowerShell prompt and run the following command:
 
 ```powershell
-Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://aliae.dev/install.ps1'))
+Set-ExecutionPolicy Bypass -Scope Process -Force; Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://trajano.github.io/aliae/install.ps1'))
 ```
 
 </TabItem>

--- a/website/static/install.ps1
+++ b/website/static/install.ps1
@@ -14,7 +14,7 @@ if ($IsMacOS) {
     Write-Host @"
 $installInstructions
 
-https://aliae.dev/docs/installation/macos
+https://trajano.github.io/aliae/docs/installation/macos
 "@
     exit
 }
@@ -22,7 +22,7 @@ if ($IsLinux) {
     Write-Host @"
 $installInstructions
 
-https://aliae.dev/docs/installation/linux
+https://trajano.github.io/aliae/docs/installation/linux
 "@
     exit
 }
@@ -59,7 +59,7 @@ if (Get-Command -Name New-TemporaryFile -ErrorAction SilentlyContinue) {
 else {
     $tmp = New-Item -Path $env:TEMP -Name ([System.IO.Path]::GetRandomFileName() -replace '\.\w+$', '.exe') -Force -ItemType File
 }
-$url = "https://github.com/JanDeDobbeleer/aliae/releases/latest/download/$installer"
+$url = "https://github.com/trajano/aliae/releases/latest/download/$installer"
 
 # check if we can make https requests and download the binary
 try {
@@ -85,5 +85,5 @@ Done!
 Restart your terminal and have a look at the
 documentation on how to proceed from here.
 
-https://aliae.dev/docs/setup/shell
+https://trajano.github.io/aliae/docs/setup/shell
 '@

--- a/website/static/install.sh
+++ b/website/static/install.sh
@@ -81,7 +81,7 @@ validate_install_directory() {
 
     # check if we can write to the install directory
     if [ ! -w $install_dir ]; then
-        error "Cannot write to ${install_dir}. Please run the script with sudo and try again:\n  curl -s https://aliae.dev/install.sh | sudo bash -s\n\nAlternatively, you can set a different directory and try again: \n  curl -s https://aliae.dev/install.sh | bash -s -- -d {directory}"
+        error "Cannot write to ${install_dir}. Please run the script with sudo and try again:\n  curl -s https://trajano.github.io/aliae/install.sh | sudo bash -s\n\nAlternatively, you can set a different directory and try again: \n  curl -s https://trajano.github.io/aliae/install.sh | bash -s -- -d {directory}"
     fi
 
     # check if the directory is in the PATH
@@ -122,7 +122,7 @@ install() {
     info "\nℹ️  Installing aliae for ${target} in ${install_dir}"
 
     executable=${install_dir}/aliae
-    url=https://github.com/JanDeDobbeleer/aliae/releases/latest/download/aliae-${target}
+    url=https://github.com/trajano/aliae/releases/latest/download/aliae-${target}
 
     info "⬇️  Downloading aliae from ${url}"
 
@@ -133,7 +133,7 @@ install() {
 
     chmod +x $executable
 
-    info "🚀 Installation complete.\n\nYou can follow the instructions at https://aliae.dev/docs/setup/shell"
+    info "🚀 Installation complete.\n\nYou can follow the instructions at https://trajano.github.io/aliae/docs/setup/shell"
     info "to setup your shell to use aliae.\n"
 }
 


### PR DESCRIPTION
## Summary
- update `install.sh` and `install.ps1` to use `trajano/aliae` release assets and fork docs URLs
- update Linux/macOS/Windows manual install commands to use `trajano.github.io/aliae`
- add explicit note in manual tabs that commands install from the fork, not official upstream

## Validation
- `cd website && npm ci && npm run build`