### PR TITLE
fix: default init tty-only to true

### DIFF
--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -19,7 +19,8 @@ var (
 		Short: "Initialize your shell and config",
 		Long: `Initialize your shell and config.
 
-See the documentation to initialize your shell: https://aliae.dev/docs/setup/shell.`,
+See the documentation to initialize your shell: https://trajano.github.io/aliae/docs/setup/shell.
+This is a personal fork. For the official project and docs, see https://aliae.dev.`,
 		ValidArgs: []string{
 			"bash",
 			"zsh",
@@ -44,7 +45,7 @@ See the documentation to initialize your shell: https://aliae.dev/docs/setup/she
 
 func init() {
 	initCmd.Flags().BoolVarP(&printOutput, "print", "p", false, "print the init script")
-	initCmd.Flags().BoolVar(&ttyOnly, "tty-only", false, "only print if output is a TTY")
+	initCmd.Flags().BoolVar(&ttyOnly, "tty-only", true, "only print if output is a TTY (default: true)")
 	_ = initCmd.MarkPersistentFlagRequired("config")
 	RootCmd.AddCommand(initCmd)
 }

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -21,7 +21,8 @@ var RootCmd = &cobra.Command{
 	Long: `aliae is a tool to do cross platform shell management.
 It can use the same configuration everywhere to offer a consistent
 experience, regardless of where you are. For a detailed guide
-on getting started, have a look at the docs at https://aliae.dev`,
+on getting started, have a look at the docs at https://trajano.github.io/aliae.
+This is a personal fork. For the official project and docs, see https://aliae.dev`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if displayVersion {
 			fmt.Println(cliVersion)

--- a/website/docs/setup/shell.mdx
+++ b/website/docs/setup/shell.mdx
@@ -7,6 +7,14 @@ sidebar_label: 🐚 Shell
 import Tabs from "@theme/Tabs";
 import TabItem from "@theme/TabItem";
 
+:::info
+`aliae init` uses `--tty-only=true` by default. If you need output in a non-TTY context (for example in CI or scripted piping), run:
+
+```bash
+aliae init <shell> --tty-only=false
+```
+:::
+
 <Tabs
   defaultValue="powershell"
   groupId="shell"


### PR DESCRIPTION
## Summary
- change `aliae init` so `--tty-only` defaults to `true`
- update CLI help text links to point to fork docs and include a personal-fork notice with official `aliae.dev`
- document the `--tty-only=true` default in shell setup docs, including how to disable it when needed

## Validation
- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`
- `cd website && npm ci && npm run build`