### PR TITLE
ci: run scoop update after release workflow

### DIFF
--- a/.github/workflows/scoop.yml
+++ b/.github/workflows/scoop.yml
@@ -3,6 +3,11 @@ on:
   release:
     types:
       - published
+  workflow_run:
+    workflows:
+      - Release
+    types:
+      - completed
   workflow_dispatch:
     inputs:
       version:
@@ -15,6 +20,7 @@ permissions:
 
 jobs:
   update-manifest:
+    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == github.event.repository.default_branch) }}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary
- fix Scoop automation trigger so it also runs after the `Release` workflow completes successfully on the default branch
- keep existing `release.published` and `workflow_dispatch` triggers

## Why
Releases created by GitHub Actions using `github.token` may not trigger downstream workflows via `release` events, which caused `bucket/aliae.json` to lag.