### PR TITLE
fix: handle tty-only correctly for piped stdout

### DIFF
--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -51,9 +51,15 @@ func init() {
 }
 
 func runInit(shellName string) {
-	if ttyOnly && !term.IsTerminal(int(os.Stdout.Fd())) {
+	stdinTTY := term.IsTerminal(int(os.Stdin.Fd()))
+	stdoutTTY := term.IsTerminal(int(os.Stdout.Fd()))
+	if shouldSkipInitOutput(ttyOnly, stdinTTY, stdoutTTY) {
 		return
 	}
 	init := cfg.Init(config, shellName, printOutput)
 	fmt.Print(init)
+}
+
+func shouldSkipInitOutput(ttyOnly, stdinTTY, stdoutTTY bool) bool {
+	return ttyOnly && !stdinTTY && !stdoutTTY
 }

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -1,0 +1,54 @@
+package cli
+
+import "testing"
+
+func TestShouldSkipInitOutput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		ttyOnly   bool
+		stdinTTY  bool
+		stdoutTTY bool
+		wantSkip  bool
+	}{
+		{
+			name:      "tty-only disabled",
+			ttyOnly:   false,
+			stdinTTY:  false,
+			stdoutTTY: false,
+			wantSkip:  false,
+		},
+		{
+			name:      "interactive terminal",
+			ttyOnly:   true,
+			stdinTTY:  true,
+			stdoutTTY: true,
+			wantSkip:  false,
+		},
+		{
+			name:      "piped output but interactive input should still print",
+			ttyOnly:   true,
+			stdinTTY:  true,
+			stdoutTTY: false,
+			wantSkip:  false,
+		},
+		{
+			name:      "non-interactive process",
+			ttyOnly:   true,
+			stdinTTY:  false,
+			stdoutTTY: false,
+			wantSkip:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := shouldSkipInitOutput(tt.ttyOnly, tt.stdinTTY, tt.stdoutTTY)
+			if got != tt.wantSkip {
+				t.Fatalf("shouldSkipInitOutput() = %v, want %v", got, tt.wantSkip)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- fix `aliae init` tty-only behavior so it does not suppress output when stdin is interactive but stdout is piped
- add regression test coverage for tty-only decision logic (`src/cli/init_test.go`)

## Validation
- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`