### PR TITLE
fix: add tty diagnostics and disable tty-only default

### DIFF
--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -45,7 +45,7 @@ This is a personal fork. For the official project and docs, see https://aliae.de
 
 func init() {
 	initCmd.Flags().BoolVarP(&printOutput, "print", "p", false, "print the init script")
-	initCmd.Flags().BoolVar(&ttyOnly, "tty-only", true, "only print if output is a TTY (default: true)")
+	initCmd.Flags().BoolVar(&ttyOnly, "tty-only", false, "only print if output is a TTY (default: false)")
 	_ = initCmd.MarkPersistentFlagRequired("config")
 	RootCmd.AddCommand(initCmd)
 }

--- a/src/cli/root.go
+++ b/src/cli/root.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/term"
 )
 
 var (
@@ -22,12 +23,21 @@ var RootCmd = &cobra.Command{
 It can use the same configuration everywhere to offer a consistent
 experience, regardless of where you are. For a detailed guide
 on getting started, have a look at the docs at https://trajano.github.io/aliae.
-This is a personal fork. For the official project and docs, see https://aliae.dev`,
+This is a personal fork. For the official project and docs, see https://aliae.dev.
+TTY check: stdin=<dynamic> stdout=<dynamic>`,
 	Run: func(cmd *cobra.Command, _ []string) {
 		if displayVersion {
 			fmt.Println(cliVersion)
 			return
 		}
+		stdinTTY := term.IsTerminal(int(os.Stdin.Fd()))
+		stdoutTTY := term.IsTerminal(int(os.Stdout.Fd()))
+		cmd.Long = fmt.Sprintf(`aliae is a tool to do cross platform shell management.
+It can use the same configuration everywhere to offer a consistent
+experience, regardless of where you are. For a detailed guide
+on getting started, have a look at the docs at https://trajano.github.io/aliae.
+This is a personal fork. For the official project and docs, see https://aliae.dev.
+TTY check: stdin=%t stdout=%t`, stdinTTY, stdoutTTY)
 		_ = cmd.Help()
 	},
 }


### PR DESCRIPTION
## Summary
- set `aliae init --tty-only` default back to `false`
- add runtime TTY diagnostics to root help output after the personal-fork notice (`stdin` and `stdout` values)

## Validation
- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`