### PR TITLE
fix: resolve get shell correctly in Git Bash

### DIFF
--- a/src/shell/name.go
+++ b/src/shell/name.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"os"
+	"path/filepath"
 	"strings"
 
 	"github.com/shirou/gopsutil/process"
@@ -20,7 +21,8 @@ func Name() string {
 	}
 
 	executable, _ := os.Executable()
-	if name == executable {
+	executable = filepath.Base(executable)
+	if shouldUseParentShell(name, executable) {
 		p, _ = p.Parent()
 		name, err = p.Name()
 	}
@@ -30,4 +32,10 @@ func Name() string {
 	}
 
 	return strings.TrimSuffix(name, ".exe")
+}
+
+func shouldUseParentShell(name, executable string) bool {
+	normalizedName := strings.TrimSuffix(filepath.Base(name), ".exe")
+	normalizedExecutable := strings.TrimSuffix(filepath.Base(executable), ".exe")
+	return normalizedName == normalizedExecutable
 }

--- a/src/shell/name_test.go
+++ b/src/shell/name_test.go
@@ -1,0 +1,11 @@
+package shell
+
+import "testing"
+
+func TestShouldUseParentShell(t *testing.T) {
+	t.Parallel()
+
+	if !shouldUseParentShell("aliae", "aliae.exe") {
+		t.Fatal("expected to use parent shell when process is aliae")
+	}
+}


### PR DESCRIPTION
## Summary
- fix shell name detection by normalizing executable and process names before comparison
- ensure `aliae get shell` correctly falls back to parent process in Git Bash on Windows
- add regression test for parent-shell fallback decision

## Validation
- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`