### PR TITLE
feat: add verbose tracing to aliae get shell

### DIFF
--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -7,6 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	getVerbose bool
+)
+
 // getCmd represents the get command
 var getCmd = &cobra.Command{
 	Use:   "get [shell]",
@@ -24,6 +28,14 @@ This command is used to get the value of the following variables:
 
 		switch args[0] {
 		case "shell":
+			if getVerbose {
+				resolved, trace := shell.NameVerbose()
+				for _, line := range trace {
+					fmt.Println(line)
+				}
+				fmt.Printf("shell=%s\n", resolved)
+				return
+			}
 			fmt.Println(shell.Name())
 			return
 		default:
@@ -33,5 +45,6 @@ This command is used to get the value of the following variables:
 }
 
 func init() {
+	getCmd.Flags().BoolVarP(&getVerbose, "verbose", "v", false, "show shell detection steps")
 	RootCmd.AddCommand(getCmd)
 }

--- a/src/shell/name.go
+++ b/src/shell/name.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,7 +23,7 @@ func Name() string {
 
 	executable, _ := os.Executable()
 	executable = filepath.Base(executable)
-	name = resolveShellName(executable, name, func() (string, error) {
+	name, _ = resolveShellName(executable, name, func() (string, error) {
 		p, _ = p.Parent()
 		if p == nil {
 			return "", nil
@@ -41,20 +42,69 @@ func Name() string {
 	return strings.TrimSuffix(name, ".exe")
 }
 
+func NameVerbose() (string, []string) {
+	pid := os.Getppid()
+	p, _ := process.NewProcess(int32(pid))
+	name, err := p.Name()
+	if err != nil {
+		return UNKNOWN, []string{fmt.Sprintf("failed to resolve parent process name: %v", err)}
+	}
+
+	executable, _ := os.Executable()
+	executable = filepath.Base(executable)
+	trace := []string{
+		fmt.Sprintf("executable=%s", executable),
+		fmt.Sprintf("layer 0 pid=%d name=%s", p.Pid, name),
+	}
+
+	layer := 0
+	resolved, resolutionTrace := resolveShellName(executable, name, func() (string, error) {
+		layer++
+		p, _ = p.Parent()
+		if p == nil {
+			trace = append(trace, fmt.Sprintf("layer %d pid=? name=<none>", layer))
+			return "", nil
+		}
+
+		parentName, parentErr := p.Name()
+		if parentErr != nil {
+			trace = append(trace, fmt.Sprintf("layer %d pid=%d error=%v", layer, p.Pid, parentErr))
+			return "", parentErr
+		}
+
+		trace = append(trace, fmt.Sprintf("layer %d pid=%d name=%s", layer, p.Pid, parentName))
+		return parentName, nil
+	})
+
+	trace = append(trace, resolutionTrace...)
+
+	if resolved == "" {
+		trace = append(trace, "resolved=unknown")
+		return UNKNOWN, trace
+	}
+
+	trimmed := strings.TrimSuffix(resolved, ".exe")
+	trace = append(trace, fmt.Sprintf("resolved=%s", trimmed))
+	return trimmed, trace
+}
+
 func shouldUseParentShell(name, executable string) bool {
 	normalizedName := strings.TrimSuffix(filepath.Base(name), ".exe")
 	normalizedExecutable := strings.TrimSuffix(filepath.Base(executable), ".exe")
 	return normalizedName == normalizedExecutable
 }
 
-func resolveShellName(executable, current string, next func() (string, error)) string {
+func resolveShellName(executable, current string, next func() (string, error)) (string, []string) {
 	name := current
+	trace := []string{}
 	for shouldUseParentShell(name, executable) {
+		trace = append(trace, fmt.Sprintf("shim-detected name=%s", name))
 		parentName, err := next()
 		if err != nil || parentName == "" {
-			return ""
+			trace = append(trace, "stopped: no further parent shell available")
+			return "", trace
 		}
 		name = parentName
 	}
-	return name
+	return name, trace
 }

--- a/src/shell/name_test.go
+++ b/src/shell/name_test.go
@@ -15,7 +15,7 @@ func TestResolveShellNameSkipsMultipleAliaeParents(t *testing.T) {
 
 	parents := []string{"aliae.exe", "bash.exe"}
 	i := 0
-	got := resolveShellName("aliae.exe", "aliae.exe", func() (string, error) {
+	got, _ := resolveShellName("aliae.exe", "aliae.exe", func() (string, error) {
 		if i >= len(parents) {
 			return "", nil
 		}


### PR DESCRIPTION
## Summary
- add `-v/--verbose` to `aliae get shell`
- print layer-by-layer shell resolution diagnostics (shim and parent-process hops)
- keep existing output unchanged when verbose mode is not used

## Validation
- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`