### PR TITLE
fix: handle scoop shim name mismatch in shell detection

### DIFF
--- a/src/shell/name.go
+++ b/src/shell/name.go
@@ -91,7 +91,10 @@ func NameVerbose() (string, []string) {
 func shouldUseParentShell(name, executable string) bool {
 	normalizedName := strings.TrimSuffix(filepath.Base(name), ".exe")
 	normalizedExecutable := strings.TrimSuffix(filepath.Base(executable), ".exe")
-	return normalizedName == normalizedExecutable
+	if normalizedName == normalizedExecutable {
+		return true
+	}
+	return normalizedName == "aliae" && strings.HasPrefix(normalizedExecutable, "aliae-")
 }
 
 func resolveShellName(executable, current string, next func() (string, error)) (string, []string) {

--- a/src/shell/name_test.go
+++ b/src/shell/name_test.go
@@ -28,3 +28,22 @@ func TestResolveShellNameSkipsMultipleAliaeParents(t *testing.T) {
 		t.Fatalf("resolveShellName() = %q, want %q", got, "bash.exe")
 	}
 }
+
+func TestResolveShellNameSkipsScoopShimWhenExecutableNameDiffers(t *testing.T) {
+	t.Parallel()
+
+	parents := []string{"bash.exe"}
+	i := 0
+	got, _ := resolveShellName("aliae-windows-amd64.exe", "aliae.exe", func() (string, error) {
+		if i >= len(parents) {
+			return "", nil
+		}
+		name := parents[i]
+		i++
+		return name, nil
+	})
+
+	if got != "bash.exe" {
+		t.Fatalf("resolveShellName() = %q, want %q", got, "bash.exe")
+	}
+}


### PR DESCRIPTION
## Summary
- fix shell-resolution hop logic for Scoop shim naming mismatch (`aliae.exe` parent vs `aliae-windows-*.exe` executable)
- treat `aliae` shim name as self-hop for binaries prefixed with `aliae-`
- add regression test for this exact Scoop shim scenario

## Validation
- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`