### PR TITLE
docs: restore tty-only default and document get shell -v

### DIFF
--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -45,7 +45,7 @@ This is a personal fork. For the official project and docs, see https://aliae.de
 
 func init() {
 	initCmd.Flags().BoolVarP(&printOutput, "print", "p", false, "print the init script")
-	initCmd.Flags().BoolVar(&ttyOnly, "tty-only", false, "only print if output is a TTY (default: false)")
+	initCmd.Flags().BoolVar(&ttyOnly, "tty-only", true, "only print if output is a TTY (default: true)")
 	_ = initCmd.MarkPersistentFlagRequired("config")
 	RootCmd.AddCommand(initCmd)
 }

--- a/website/docs/setup/get.mdx
+++ b/website/docs/setup/get.mdx
@@ -1,0 +1,30 @@
+---
+id: get
+title: Get
+sidebar_label: 🔎 Get
+---
+
+Use `aliae get` to read runtime values.
+
+## Shell
+
+Print the detected shell:
+
+```bash
+aliae get shell
+```
+
+## Verbose shell tracing
+
+Use verbose mode to debug shell detection layers (for example Scoop shims):
+
+```bash
+aliae get shell -v
+```
+
+Verbose output includes:
+
+- executable name
+- process layers (`layer 0`, `layer 1`, ...)
+- shim detection hops
+- final resolved shell

--- a/website/sidebars.js
+++ b/website/sidebars.js
@@ -18,6 +18,7 @@ module.exports = {
       items: [
         "setup/configuration",
         "setup/shell",
+        "setup/get",
         "setup/alias",
         "setup/env",
         "setup/path",


### PR DESCRIPTION
## Summary
- set `aliae init --tty-only` default back to `true`
- add setup docs for `aliae get shell` and `aliae get shell -v`
- include the new setup/get page in docs sidebar

## Validation
- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`
- `cd website && npm ci && npm run build`