### PR TITLE
fix(path): dedupe msys and windows path forms

### DIFF
--- a/src/context/os.go
+++ b/src/context/os.go
@@ -1,10 +1,20 @@
 package context
 
+import "os"
+
 const (
 	WINDOWS = "windows"
 	LINUX   = "linux"
 	DARWIN  = "darwin"
 )
+
+func isMSYS2Shell() bool {
+	if Current == nil {
+		return false
+	}
+
+	return Current.OS == WINDOWS && Current.Shell == "bash" && os.Getenv("MSYSTEM") != ""
+}
 
 func PathDelimiter() string {
 	if Current == nil {
@@ -13,6 +23,9 @@ func PathDelimiter() string {
 
 	switch Current.OS {
 	case WINDOWS:
+		if isMSYS2Shell() {
+			return ":"
+		}
 		return ";"
 	default:
 		return ":"
@@ -26,6 +39,9 @@ func PathSeparator() string {
 
 	switch Current.OS {
 	case WINDOWS:
+		if isMSYS2Shell() {
+			return "/"
+		}
 		return "\\"
 	default:
 		return "/"

--- a/src/context/path.go
+++ b/src/context/path.go
@@ -25,14 +25,15 @@ func getPath() *Path {
 }
 
 func (p *Path) Append(path string) {
-	if len(path) == 0 || p.Contains(cleanPath(path)) {
+	clean := cleanPath(path)
+	if len(clean) == 0 || p.Contains(clean) {
 		return
 	}
 
 	current := os.Getenv("PATH")
-	os.Setenv("PATH", fmt.Sprintf("%s%s%s", path, PathDelimiter(), current))
+	os.Setenv("PATH", fmt.Sprintf("%s%s%s", clean, PathDelimiter(), current))
 
-	*p = append(*p, path)
+	*p = append(*p, clean)
 }
 
 func (p *Path) Contains(path string) bool {
@@ -40,5 +41,38 @@ func (p *Path) Contains(path string) bool {
 }
 
 func cleanPath(path string) string {
-	return strings.TrimRight(path, PathSeparator())
+	path = strings.TrimSpace(path)
+	if len(path) == 0 {
+		return path
+	}
+
+	if isMSYS2Shell() {
+		if normalized, OK := windowsToMSYSPath(path); OK {
+			path = normalized
+		}
+	}
+
+	return strings.TrimRight(path, `/\`)
+}
+
+func windowsToMSYSPath(path string) (string, bool) {
+	if len(path) < 3 || path[1] != ':' {
+		return "", false
+	}
+
+	drive := path[0]
+	if !isASCIIAlpha(drive) {
+		return "", false
+	}
+
+	if path[2] != '\\' && path[2] != '/' {
+		return "", false
+	}
+
+	rest := strings.ReplaceAll(path[2:], `\`, `/`)
+	return fmt.Sprintf("/%s%s", strings.ToLower(string(drive)), rest), true
+}
+
+func isASCIIAlpha(value byte) bool {
+	return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z')
 }

--- a/src/context/path_test.go
+++ b/src/context/path_test.go
@@ -1,0 +1,37 @@
+package context
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPathDelimiterWindowsMSYS2(t *testing.T) {
+	t.Setenv("MSYSTEM", "MINGW64")
+	Current = &Runtime{OS: WINDOWS, Shell: "bash"}
+
+	assert.Equal(t, ":", PathDelimiter())
+	assert.Equal(t, "/", PathSeparator())
+}
+
+func TestPathDelimiterWindowsNonMSYS2(t *testing.T) {
+	t.Setenv("MSYSTEM", "")
+	Current = &Runtime{OS: WINDOWS, Shell: "pwsh"}
+
+	assert.Equal(t, ";", PathDelimiter())
+	assert.Equal(t, "\\", PathSeparator())
+}
+
+func TestPathContainsEquivalentWindowsAndMSYS2Forms(t *testing.T) {
+	t.Setenv("MSYSTEM", "MINGW64")
+	t.Setenv("PATH", "")
+	Current = &Runtime{OS: WINDOWS, Shell: "bash"}
+
+	path := &Path{}
+	path.Append(`C:\Users\trajano\AppData\Local\Android\Sdk\platform-tools`)
+
+	assert.True(t, path.Contains(`/c/Users/trajano/AppData/Local/Android/Sdk/platform-tools`))
+
+	path.Append(`/c/Users/trajano/AppData/Local/Android/Sdk/platform-tools`)
+	assert.Len(t, *path, 1)
+}


### PR DESCRIPTION
## Summary
- normalize PATH delimiter/separator for Windows Git Bash/MSYS2 in context logic
- canonicalize path forms so C:\\... and /c/... dedupe correctly
- store canonicalized entries during append to avoid duplicate variants
- add context tests for MSYS2 delimiter/separator and equivalent-form dedupe

## Validation
- cd src && go fmt ./...
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
