### PR TITLE
fix(cdpath): avoid blank CDPATH entries on bash

### DIFF
--- a/src/shell/bash.go
+++ b/src/shell/bash.go
@@ -53,7 +53,7 @@ func (p *Path) bash() *Path {
 }
 
 func (p *CDPath) bash() *CDPath {
-	template := fmt.Sprintf(`export CDPATH="$CDPATH%s{{ .Value }}"`, context.PathDelimiter())
+	template := fmt.Sprintf(`export CDPATH="${CDPATH:+$CDPATH%s}{{ .Value }}"`, context.PathDelimiter())
 	p.template = template
 	return p
 }

--- a/src/shell/cdpath.go
+++ b/src/shell/cdpath.go
@@ -1,7 +1,6 @@
 package shell
 
 import (
-	"fmt"
 	"strings"
 
 	"github.com/jandedobbeleer/aliae/src/context"
@@ -86,7 +85,7 @@ func (p *CDPath) render() string {
 func cdpathCurrentDirScript() string {
 	switch context.Current.Shell {
 	case BASH:
-		return fmt.Sprintf(`export CDPATH=".%s$CDPATH"`, context.PathDelimiter())
+		return `if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`
 	case ZSH:
 		return `cdpath=( . $cdpath )`
 	case FISH:

--- a/src/shell/cdpath_test.go
+++ b/src/shell/cdpath_test.go
@@ -52,7 +52,7 @@ func TestCDPath(t *testing.T) {
 			CDPath: &CDPath{
 				Value: "/usr/local/share",
 			},
-			Expected: `export CDPATH="$CDPATH:/usr/local/share"`,
+			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"`,
 		},
 		{
 			Case:  "BASH - multiple items",
@@ -60,8 +60,8 @@ func TestCDPath(t *testing.T) {
 			CDPath: &CDPath{
 				Value: "/usr/local/share\n/usr/share",
 			},
-			Expected: `export CDPATH="$CDPATH:/usr/local/share"
-export CDPATH="$CDPATH:/usr/share"`,
+			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"
+export CDPATH="${CDPATH:+$CDPATH:}/usr/share"`,
 		},
 		{
 			Case:  "ZSH - single item",
@@ -130,7 +130,7 @@ func TestCDPathForce(t *testing.T) {
 				Value: "/usr/local/share",
 				Force: true,
 			},
-			Expected: `export CDPATH="$CDPATH:/usr/local/share"`,
+			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"`,
 		},
 	}
 
@@ -169,8 +169,8 @@ func TestCDPathRender(t *testing.T) {
 				&CDPath{Value: "/usr/share", If: `eq .Shell "bash"`},
 			},
 			Shell: BASH,
-			Expected: `export CDPATH="$CDPATH:/usr/share"
-export CDPATH=".:$CDPATH"`,
+			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/share"
+if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`,
 		},
 		{
 			Case: "Single definition with non-empty script",
@@ -181,8 +181,8 @@ export CDPATH=".:$CDPATH"`,
 			NonEmptyScript: true,
 			Expected: `foo
 
-export CDPATH="$CDPATH:/usr/share"
-export CDPATH=".:$CDPATH"`,
+export CDPATH="${CDPATH:+$CDPATH:}/usr/share"
+if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`,
 		},
 		{
 			Case: "Two definitions",
@@ -191,9 +191,9 @@ export CDPATH=".:$CDPATH"`,
 				&CDPath{Value: "/usr/local/share"},
 			},
 			Shell: BASH,
-			Expected: `export CDPATH="$CDPATH:/usr/share"
-export CDPATH="$CDPATH:/usr/local/share"
-export CDPATH=".:$CDPATH"`,
+			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/share"
+export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"
+if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`,
 		},
 	}
 
@@ -224,14 +224,14 @@ func TestCDPathIfExists(t *testing.T) {
 		Value:    Template(existing + "\n" + missing),
 		IfExists: true,
 	}
-	assert.Equal(t, `export CDPATH="$CDPATH:`+existing+`"`, withExists.string(), "ifExists true keeps only existing entries")
+	assert.Equal(t, `export CDPATH="${CDPATH:+$CDPATH:}`+existing+`"`, withExists.string(), "ifExists true keeps only existing entries")
 
 	context.Current.CDPath = &context.Path{}
 	withoutExists := &CDPath{
 		Value:    Template(missing),
 		IfExists: false,
 	}
-	assert.Equal(t, `export CDPATH="$CDPATH:`+missing+`"`, withoutExists.string(), "ifExists false keeps current behavior")
+	assert.Equal(t, `export CDPATH="${CDPATH:+$CDPATH:}`+missing+`"`, withoutExists.string(), "ifExists false keeps current behavior")
 }
 
 func TestCDPathEnsuresCurrentDir(t *testing.T) {
@@ -242,7 +242,9 @@ func TestCDPathEnsuresCurrentDir(t *testing.T) {
 	}
 	paths := CDPaths{&CDPath{Value: "/usr/local/share"}}
 	paths.Render()
-	assert.Equal(t, `export CDPATH="$CDPATH:/usr/local/share"`+"\n"+`export CDPATH=".:$CDPATH"`, strings.TrimSpace(DotFile.String()))
+	expected := `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"` + "\n" +
+		`if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`
+	assert.Equal(t, expected, strings.TrimSpace(DotFile.String()))
 }
 
 func TestCDPathDoesNotInjectCurrentDirWhenAlreadyPresent(t *testing.T) {
@@ -254,7 +256,7 @@ func TestCDPathDoesNotInjectCurrentDirWhenAlreadyPresent(t *testing.T) {
 
 	paths := CDPaths{&CDPath{Value: "/usr/local/share"}}
 	paths.Render()
-	assert.Equal(t, `export CDPATH="$CDPATH:/usr/local/share"`, strings.TrimSpace(DotFile.String()))
+	assert.Equal(t, `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"`, strings.TrimSpace(DotFile.String()))
 }
 
 func TestCDPathWithExistingCurrentDirSkipsDotInsertion(t *testing.T) {
@@ -263,5 +265,5 @@ func TestCDPathWithExistingCurrentDirSkipsDotInsertion(t *testing.T) {
 		CDPath: &context.Path{".", "/existing"},
 	}
 	cdpath := &CDPath{Value: "/usr/local/share"}
-	assert.Equal(t, `export CDPATH="$CDPATH:/usr/local/share"`, cdpath.string())
+	assert.Equal(t, `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"`, cdpath.string())
 }


### PR DESCRIPTION
## Summary
- fix bash CDPATH rendering so an empty existing CDPATH does not create blank path entries
- keep configured cdpath entries appended while prepending . only when missing
- add/adjust tests for empty/existing CDPATH and . handling

## Validation
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
