### PR TITLE
perf(build): enable trimpath for release binaries

### DIFF
--- a/src/.goreleaser.yml
+++ b/src/.goreleaser.yml
@@ -12,6 +12,7 @@ builds:
     no_unique_dist_dir: true
     flags:
       - -a
+      - -trimpath
     ldflags:
       - -s -w -X main.Version={{.Version}} -extldflags "-static"
     tags:


### PR DESCRIPTION
## Summary
- add -trimpath to GoReleaser build flags
- keep existing -s -w stripping behavior
- reduce release binary metadata for smaller artifacts and reproducible paths

## Validation
- cd src && go fmt ./...
- cd src && go mod tidy
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run