### PR TITLE
fix(cli): gate tty-only init on stdin interactivity

### DIFF
--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -52,8 +52,7 @@ func init() {
 
 func runInit(shellName string) {
 	stdinTTY := term.IsTerminal(int(os.Stdin.Fd()))
-	stdoutTTY := term.IsTerminal(int(os.Stdout.Fd()))
-	skip := shouldSkipInitOutput(ttyOnly, stdinTTY, stdoutTTY)
+	skip := shouldSkipInitOutput(ttyOnly, stdinTTY)
 	if skip {
 		return
 	}
@@ -61,6 +60,6 @@ func runInit(shellName string) {
 	fmt.Print(init)
 }
 
-func shouldSkipInitOutput(ttyOnly, stdinTTY, stdoutTTY bool) bool {
-	return ttyOnly && !stdinTTY && !stdoutTTY
+func shouldSkipInitOutput(ttyOnly, stdinTTY bool) bool {
+	return ttyOnly && !stdinTTY
 }

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -6,46 +6,47 @@ func TestShouldSkipInitOutput(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		ttyOnly   bool
-		stdinTTY  bool
-		stdoutTTY bool
-		wantSkip  bool
+		name     string
+		ttyOnly  bool
+		stdinTTY bool
+		wantSkip bool
 	}{
 		{
-			name:      "tty-only disabled",
-			ttyOnly:   false,
-			stdinTTY:  false,
-			stdoutTTY: false,
-			wantSkip:  false,
+			name:     "tty-only disabled",
+			ttyOnly:  false,
+			stdinTTY: false,
+			wantSkip: false,
 		},
 		{
-			name:      "interactive terminal",
-			ttyOnly:   true,
-			stdinTTY:  true,
-			stdoutTTY: true,
-			wantSkip:  false,
+			name:     "interactive terminal",
+			ttyOnly:  true,
+			stdinTTY: true,
+			wantSkip: false,
 		},
 		{
-			name:      "piped output but interactive input should still print",
-			ttyOnly:   true,
-			stdinTTY:  true,
-			stdoutTTY: false,
-			wantSkip:  false,
+			name:     "piped output but interactive input should still print",
+			ttyOnly:  true,
+			stdinTTY: true,
+			wantSkip: false,
 		},
 		{
-			name:      "non-interactive process",
-			ttyOnly:   true,
-			stdinTTY:  false,
-			stdoutTTY: false,
-			wantSkip:  true,
+			name:     "non-interactive process",
+			ttyOnly:  true,
+			stdinTTY: false,
+			wantSkip: true,
+		},
+		{
+			name:     "piped input should skip even when output is interactive",
+			ttyOnly:  true,
+			stdinTTY: false,
+			wantSkip: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got := shouldSkipInitOutput(tt.ttyOnly, tt.stdinTTY, tt.stdoutTTY)
+			got := shouldSkipInitOutput(tt.ttyOnly, tt.stdinTTY)
 			if got != tt.wantSkip {
 				t.Fatalf("shouldSkipInitOutput() = %v, want %v", got, tt.wantSkip)
 			}


### PR DESCRIPTION
## Summary
- change --tty-only skip logic to depend on stdin interactivity
- keep command-substitution flows working while blocking piped input
- add coverage for piped-input case in shouldSkipInitOutput tests

## Validation
- cd src && go fmt ./...
- cd src && go mod tidy
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run