### PR TITLE
perf(context): cache cleanPath normalization results

### DIFF
--- a/src/context/path.go
+++ b/src/context/path.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"slices"
 	"strings"
+	"sync"
 )
 
 type Path []string
@@ -18,6 +19,11 @@ var runCygpath = func(path string) (string, error) {
 
 	return strings.TrimSpace(string(output)), nil
 }
+
+var (
+	cleanPathCache   = map[string]string{}
+	cleanPathCacheMu sync.RWMutex
+)
 
 func getPath() *Path {
 	return getEnvPath("PATH")
@@ -80,13 +86,39 @@ func cleanPath(path string) string {
 		return path
 	}
 
+	cacheKey := cleanPathCacheKey(path)
+	cleanPathCacheMu.RLock()
+	cached, ok := cleanPathCache[cacheKey]
+	cleanPathCacheMu.RUnlock()
+	if ok {
+		return cached
+	}
+
 	if isMSYS2Shell() {
 		if normalized, err := runCygpath(path); err == nil && normalized != "" {
 			path = normalized
 		}
 	}
 
-	return strings.TrimRight(path, `/\`)
+	clean := strings.TrimRight(path, `/\`)
+	cleanPathCacheMu.Lock()
+	cleanPathCache[cacheKey] = clean
+	cleanPathCacheMu.Unlock()
+	return clean
+}
+
+func cleanPathCacheKey(path string) string {
+	if Current == nil {
+		return "|:" + os.Getenv("MSYSTEM") + ":" + path
+	}
+
+	return Current.OS + "|" + Current.Shell + ":" + os.Getenv("MSYSTEM") + ":" + path
+}
+
+func clearCleanPathCache() {
+	cleanPathCacheMu.Lock()
+	defer cleanPathCacheMu.Unlock()
+	cleanPathCache = map[string]string{}
 }
 
 func isASCIIAlpha(value byte) bool {

--- a/src/context/path_test.go
+++ b/src/context/path_test.go
@@ -27,6 +27,8 @@ func TestPathContainsEquivalentWindowsAndMSYS2Forms(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
 	t.Setenv("PATH", "")
 	Current = &Runtime{OS: WINDOWS, Shell: "bash"}
+	clearCleanPathCache()
+	t.Cleanup(clearCleanPathCache)
 
 	originalRunCygpath := runCygpath
 	t.Cleanup(func() { runCygpath = originalRunCygpath })
@@ -75,6 +77,8 @@ func TestGetPathDoesNotMutateEnvironmentPath(t *testing.T) {
 func TestCleanPathUsesCygpath(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
 	Current = &Runtime{OS: WINDOWS, Shell: "bash"}
+	clearCleanPathCache()
+	t.Cleanup(clearCleanPathCache)
 
 	originalRunCygpath := runCygpath
 	t.Cleanup(func() { runCygpath = originalRunCygpath })
@@ -90,6 +94,8 @@ func TestCleanPathUsesCygpath(t *testing.T) {
 func TestCleanPathKeepsWindowsPathWhenCygpathFails(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
 	Current = &Runtime{OS: WINDOWS, Shell: "bash"}
+	clearCleanPathCache()
+	t.Cleanup(clearCleanPathCache)
 
 	originalRunCygpath := runCygpath
 	t.Cleanup(func() { runCygpath = originalRunCygpath })
@@ -99,4 +105,25 @@ func TestCleanPathKeepsWindowsPathWhenCygpathFails(t *testing.T) {
 	}
 
 	assert.Equal(t, `C:\Users\trajano\bin`, cleanPath(`C:\Users\trajano\bin\`))
+}
+
+func TestCleanPathCachesCygpathResult(t *testing.T) {
+	t.Setenv("MSYSTEM", "MINGW64")
+	Current = &Runtime{OS: WINDOWS, Shell: "bash"}
+	clearCleanPathCache()
+	t.Cleanup(clearCleanPathCache)
+
+	originalRunCygpath := runCygpath
+	t.Cleanup(func() { runCygpath = originalRunCygpath })
+
+	calls := 0
+	runCygpath = func(path string) (string, error) {
+		calls++
+		assert.Equal(t, `C:\Users\trajano\bin\`, path)
+		return "/c/Users/trajano/bin", nil
+	}
+
+	assert.Equal(t, "/c/Users/trajano/bin", cleanPath(`C:\Users\trajano\bin\`))
+	assert.Equal(t, "/c/Users/trajano/bin", cleanPath(`C:\Users\trajano\bin\`))
+	assert.Equal(t, 1, calls)
 }


### PR DESCRIPTION
## Summary
- cache cleanPath normalization output per runtime context
- avoid repeated cygpath invocations for repeated path entries
- add tests to verify cache reuse and reset behavior

## Validation
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run