### PR TITLE
ci: bump Go toolchain to 1.25.7 for vuln remediation

### DIFF
--- a/.github/workflows/code.yml
+++ b/.github/workflows/code.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
       with:
-        go-version: '1.24.1'
+        go-version: '1.25.7'
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Golang CI

--- a/.github/workflows/gomod.yml
+++ b/.github/workflows/gomod.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install Go
       uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
       with:
-        go-version: '1.24.1'
+        go-version: '1.25.7'
     - name: Checkout code
       uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8
     - name: Check for unused dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Install Go 🗳
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5
         with:
-          go-version: '1.24.1'
+          go-version: '1.25.7'
       - name: Tag HEAD 😸
         run: |
           git config --global user.name "GitHub Actions"

--- a/src/go.mod
+++ b/src/go.mod
@@ -1,6 +1,8 @@
 module github.com/jandedobbeleer/aliae/src
 
-go 1.24.0
+go 1.25.0
+
+toolchain go1.25.7
 
 require (
 	github.com/goccy/go-yaml v1.19.2


### PR DESCRIPTION
## Summary
- bump GitHub Actions Go version pins from 1.24.1 to 1.25.7
- raise module language version to go 1.25.0
- add 	oolchain go1.25.7 to align local/CI runtime for stdlib vuln fixes

## Validation
- cd src && go fmt ./...
- cd src && go mod tidy
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
- cd src && go run golang.org/x/vuln/cmd/govulncheck@latest ./...