### PR TITLE
fix(bash): use empty CDPATH entry for current directory

### DIFF
--- a/src/shell/cdpath.go
+++ b/src/shell/cdpath.go
@@ -85,7 +85,7 @@ func (p *CDPath) render() string {
 func cdpathCurrentDirScript() string {
 	switch context.Current.Shell {
 	case BASH:
-		return `if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`
+		return `if [ -n "$CDPATH" ]; then export CDPATH=":$CDPATH"; else export CDPATH=":"; fi`
 	case ZSH:
 		return `cdpath=( . $cdpath )`
 	case FISH:

--- a/src/shell/cdpath_test.go
+++ b/src/shell/cdpath_test.go
@@ -170,7 +170,7 @@ func TestCDPathRender(t *testing.T) {
 			},
 			Shell: BASH,
 			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/share"
-if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`,
+if [ -n "$CDPATH" ]; then export CDPATH=":$CDPATH"; else export CDPATH=":"; fi`,
 		},
 		{
 			Case: "Single definition with non-empty script",
@@ -182,7 +182,7 @@ if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`
 			Expected: `foo
 
 export CDPATH="${CDPATH:+$CDPATH:}/usr/share"
-if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`,
+if [ -n "$CDPATH" ]; then export CDPATH=":$CDPATH"; else export CDPATH=":"; fi`,
 		},
 		{
 			Case: "Two definitions",
@@ -193,7 +193,7 @@ if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`
 			Shell: BASH,
 			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/share"
 export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"
-if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`,
+if [ -n "$CDPATH" ]; then export CDPATH=":$CDPATH"; else export CDPATH=":"; fi`,
 		},
 	}
 
@@ -243,7 +243,7 @@ func TestCDPathEnsuresCurrentDir(t *testing.T) {
 	paths := CDPaths{&CDPath{Value: "/usr/local/share"}}
 	paths.Render()
 	expected := `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"` + "\n" +
-		`if [ -n "$CDPATH" ]; then export CDPATH=".:$CDPATH"; else export CDPATH="."; fi`
+		`if [ -n "$CDPATH" ]; then export CDPATH=":$CDPATH"; else export CDPATH=":"; fi`
 	assert.Equal(t, expected, strings.TrimSpace(DotFile.String()))
 }
 


### PR DESCRIPTION
## Summary
- change Bash CDPATH current-directory fallback injection to use an empty first path element (:) instead of explicit .
- keep existing behavior for other shells
- update CDPATH tests to match the Bash behavior change

## Validation
- cd src && go fmt ./...
- cd src && go test ./...