### PR TITLE
chore(homebrew): point install docs to trajano/tap

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -8,4 +8,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Disabled
-      run: echo "Homebrew publishing is disabled in this fork."
+      run: echo "Homebrew publishing moved to trajano/homebrew-tap."

--- a/website/docs/installation/homebrew.mdx
+++ b/website/docs/installation/homebrew.mdx
@@ -12,7 +12,8 @@ bash shell profile script, and *[Requirements][requirements]* to build aliae.
 :::
 
 ```bash
-brew install trajano/aliae/aliae
+brew tap trajano/tap
+brew install trajano/tap/aliae
 ```
 
 ## Update


### PR DESCRIPTION
## Summary
- update Homebrew install docs to use `trajano/tap`
- clarify disabled Homebrew workflow message that publishing moved to `trajano/homebrew-tap`

## Validation
- `cd website && npm ci && npm run build` (pass)
- `npx --yes markdownlint-cli $(rg --files -g "*.md" -g "*.mdx")` (fails due existing unrelated repo-wide markdownlint issues)
