### PR TITLE
fix(shell): normalize Windows path separators for PowerShell

### DIFF
--- a/src/shell/path.go
+++ b/src/shell/path.go
@@ -118,16 +118,29 @@ func pathEntryExists(entry string) bool {
 }
 
 func normalizePathEntry(entry string) string {
-	if context.Current == nil || context.Current.OS != context.WINDOWS || context.Current.Shell != BASH || !isMSYS2Environment() {
+	if context.Current == nil || context.Current.OS != context.WINDOWS {
 		return entry
 	}
 
-	normalized, ok := windowsToMSYSPath(entry)
-	if !ok {
-		return entry
+	if context.Current.Shell == BASH && isMSYS2Environment() {
+		normalized, ok := windowsToMSYSPath(entry)
+		if !ok {
+			return entry
+		}
+
+		return normalized
 	}
 
-	return normalized
+	switch context.Current.Shell {
+	case PWSH, POWERSHELL, CMD, NU:
+		if windowsPath, ok := msysToWindowsPath(entry); ok {
+			return windowsPath
+		}
+
+		return strings.ReplaceAll(entry, "/", `\`)
+	default:
+		return entry
+	}
 }
 
 func isMSYS2Environment() bool {

--- a/src/shell/path_test.go
+++ b/src/shell/path_test.go
@@ -30,6 +30,20 @@ func TestPath(t *testing.T) {
 			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH`,
 		},
 		{
+			Case:     "PWSH - Windows converts separators",
+			Shell:    PWSH,
+			OS:       context.WINDOWS,
+			Path:     &Path{Value: "C:/Users/jan/.tools/bin"},
+			Expected: `$env:PATH = "C:\Users\jan\.tools\bin" + ';' + $env:PATH`,
+		},
+		{
+			Case:     "PWSH - Windows converts MSYS paths",
+			Shell:    PWSH,
+			OS:       context.WINDOWS,
+			Path:     &Path{Value: "/c/Users/jan/.tools/bin"},
+			Expected: `$env:PATH = "C:\Users\jan\.tools\bin" + ';' + $env:PATH`,
+		},
+		{
 			Case:     "PWSH - single item with template",
 			Shell:    PWSH,
 			Path:     &Path{Value: "{{ .Home }}/.tools/bin"},
@@ -174,6 +188,7 @@ func TestPathRender(t *testing.T) {
 	cases := []struct {
 		Case           string
 		Shell          string
+		OS             string
 		Expected       string
 		Paths          Paths
 		NonEmptyScript bool
@@ -197,6 +212,15 @@ func TestPathRender(t *testing.T) {
 			},
 			Shell:    PWSH,
 			Expected: `$env:PATH = "/usr/bin" + ':' + $env:PATH`,
+		},
+		{
+			Case: "PWSH - Windows path separators",
+			Paths: Paths{
+				&Path{Value: "C:/Users/jan/.tools/bin"},
+			},
+			Shell:    PWSH,
+			OS:       context.WINDOWS,
+			Expected: `$env:PATH = "C:\Users\jan\.tools\bin" + ';' + $env:PATH`,
 		},
 		{
 			Case: "PWSH - 1 PATH definition",
@@ -243,7 +267,7 @@ $env:PATH = "/Users/jan/.tools/bin" + ':' + $env:PATH`,
 		if tc.NonEmptyScript {
 			DotFile.WriteString("foo")
 		}
-		context.Current = &context.Runtime{Shell: tc.Shell, Path: &context.Path{}}
+		context.Current = &context.Runtime{Shell: tc.Shell, OS: tc.OS, Path: &context.Path{}}
 		tc.Paths.Render()
 		assert.Equal(t, tc.Expected, strings.TrimSpace(DotFile.String()), tc.Case)
 	}


### PR DESCRIPTION
## Summary
- normalize path entries to Windows-style separators for Windows-native shells (pwsh, powershell, cmd, 
u)
- keep existing Git Bash/MSYS conversion behavior unchanged
- add test coverage for Windows PowerShell path rendering and MSYS path conversion

## Validation
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
