### PR TITLE
fix(cli): send get shell and init output to stdout

### DIFF
--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -33,7 +33,7 @@ This command is used to get the value of the following variables:
 	RunE: func(cmd *cobra.Command, args []string) error {
 		switch args[0] {
 		case "shell":
-			cmd.Println(shell.Name())
+			fmt.Fprintln(cmd.OutOrStdout(), shell.Name())
 			return nil
 		case "config":
 			output, err := renderResolvedConfigYAML(config)

--- a/src/cli/get_test.go
+++ b/src/cli/get_test.go
@@ -1,0 +1,25 @@
+package cli
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetShellWritesToStdout(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := getCmd.RunE(cmd, []string{"shell"})
+	require.NoError(t, err)
+	assert.NotEmpty(t, strings.TrimSpace(stdout.String()))
+	assert.Empty(t, stderr.String())
+}

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -1,6 +1,7 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -55,7 +56,7 @@ func runInit(cmd *cobra.Command, shellName string) {
 		return
 	}
 	init := cfg.Init(config, shellName, printOutput)
-	cmd.Print(init)
+	fmt.Fprint(cmd.OutOrStdout(), init)
 }
 
 func shouldSkipInitOutput(ttyOnly, stdinTTY bool) bool {

--- a/src/cli/init_test.go
+++ b/src/cli/init_test.go
@@ -1,6 +1,15 @@
 package cli
 
-import "testing"
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
 
 func TestShouldSkipInitOutput(t *testing.T) {
 	t.Parallel()
@@ -52,4 +61,39 @@ func TestShouldSkipInitOutput(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestRunInitWritesToStdout(t *testing.T) {
+	originalConfig := config
+	originalPrintOutput := printOutput
+	originalTTYOnly := ttyOnly
+	t.Cleanup(func() {
+		config = originalConfig
+		printOutput = originalPrintOutput
+		ttyOnly = originalTTYOnly
+	})
+
+	configFile := filepath.Join(t.TempDir(), "aliae.yaml")
+	err := os.WriteFile(configFile, []byte(`alias:
+  - name: ll
+    value: ls -la
+`), 0o600)
+	if err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	config = configFile
+	printOutput = true
+	ttyOnly = false
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	runInit(cmd, "zsh")
+
+	assert.NotEmpty(t, strings.TrimSpace(stdout.String()))
+	assert.Empty(t, stderr.String())
 }


### PR DESCRIPTION
## Summary
- write `aliae get shell` output to `cmd.OutOrStdout()` so it is pipeable
- write `aliae init` output to `cmd.OutOrStdout()` for consistent stream behavior
- add regression tests for both command paths to assert stdout/stderr routing

## Verification
- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`
- `cd src && go run github.com/golangci/golangci-lint/cmd/golangci-lint@latest run` (fails because repo uses v2 config)
- `cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run`
