### PR TITLE
feat(config): default root cache and benchmark cache controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ focused on Git Bash support and fork-specific distribution.
 - Configuration features:
   - Added top-level `stat_timeout` to control filesystem stat/existence timeout.
   - Added top-level `cygpath` mode (`internal` default, `external` optional) to choose conversion backend.
+  - Added top-level `cache` (enabled by default) to reuse merged+validated config when source files are unchanged.
   - Added top-level `extends` with short/long syntax, cycle detection, and a depth limit.
   - Added conditional `extends[].if` support to skip individual entries when false.
   - Added top-level `progress` with weighted automatic OSC progress across `alias`, `env`,

--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -60,7 +60,10 @@ This command is used to get the value of the following variables:
 	},
 }
 
+var benchmarkNoCache bool
+
 func init() {
+	getCmd.Flags().BoolVar(&benchmarkNoCache, "no-cache", false, "disable config cache while running benchmark")
 	RootCmd.AddCommand(getCmd)
 }
 
@@ -370,6 +373,9 @@ func isSupportedBenchmarkShell(shellName string) bool {
 }
 
 func printBenchmark(out io.Writer, benchmarkShell string) error {
+	cfg.SetCacheBypass(benchmarkNoCache)
+	defer cfg.SetCacheBypass(false)
+
 	type benchmarkStep struct {
 		name     string
 		duration time.Duration
@@ -387,10 +393,14 @@ func printBenchmark(out io.Writer, benchmarkShell string) error {
 
 	totalStart := time.Now()
 	var aliae *cfg.Aliae
+	cacheUsed := false
+	cygpathMode := context.CygpathInternal
 
 	if err := record("load_config", func() error {
 		var err error
 		aliae, err = cfg.LoadConfigWithoutVars(config)
+		cacheUsed = cfg.LastLoadUsedCache()
+		cygpathMode = context.NormalizeCygpathMode(aliae.Cygpath)
 		return err
 	}); err != nil {
 		return err
@@ -409,10 +419,14 @@ func printBenchmark(out io.Writer, benchmarkShell string) error {
 		return err
 	}
 
-	if err := record("validate_config", func() error {
-		return cfg.ValidateConfig(config)
-	}); err != nil {
-		return err
+	validateSkipped := true
+	if benchmarkNoCache {
+		validateSkipped = false
+		if err := record("validate_config", func() error {
+			return cfg.ValidateConfig(config)
+		}); err != nil {
+			return err
+		}
 	}
 
 	if len(benchmarkShell) > 0 {
@@ -444,6 +458,11 @@ func printBenchmark(out io.Writer, benchmarkShell string) error {
 	fmt.Fprintln(out, "aliae get benchmark")
 	if len(benchmarkShell) > 0 {
 		fmt.Fprintf(out, "benchmark.shell=%s\n", benchmarkShell)
+	}
+	fmt.Fprintf(out, "benchmark.cache_used=%t\n", cacheUsed)
+	fmt.Fprintf(out, "benchmark.cygpath=%s\n", cygpathMode)
+	if validateSkipped {
+		fmt.Fprintln(out, "benchmark.validate_config=skipped")
 	}
 	for _, step := range steps {
 		fmt.Fprintf(out, "benchmark.%s=%s\n", step.name, step.duration)

--- a/src/cli/get_test.go
+++ b/src/cli/get_test.go
@@ -49,10 +49,12 @@ func TestGetBenchmarkWithoutShell(t *testing.T) {
 	err := getCmd.RunE(cmd, []string{"benchmark"})
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "aliae get benchmark")
+	assert.Contains(t, stdout.String(), "benchmark.cache_used=")
+	assert.Contains(t, stdout.String(), "benchmark.cygpath=")
 	assert.Contains(t, stdout.String(), "benchmark.load_config=")
 	assert.Contains(t, stdout.String(), "benchmark.evaluate_vars=")
 	assert.Contains(t, stdout.String(), "benchmark.render_config=")
-	assert.Contains(t, stdout.String(), "benchmark.validate_config=")
+	assert.Contains(t, stdout.String(), "benchmark.validate_config=skipped")
 	assert.Contains(t, stdout.String(), "benchmark.total=")
 	assert.Empty(t, stderr.String())
 }
@@ -80,9 +82,44 @@ func TestGetBenchmarkWithShell(t *testing.T) {
 	err := getCmd.RunE(cmd, []string{"benchmark", "bash"})
 	require.NoError(t, err)
 	assert.Contains(t, stdout.String(), "benchmark.shell=bash")
+	assert.Contains(t, stdout.String(), "benchmark.cache_used=")
+	assert.Contains(t, stdout.String(), "benchmark.cygpath=")
 	assert.Contains(t, stdout.String(), "benchmark.generate_init_bash=")
 	assert.Contains(t, stdout.String(), "benchmark.init.render_env=")
 	assert.Contains(t, stdout.String(), "benchmark.init.render_script=")
+	assert.Empty(t, stderr.String())
+}
+
+func TestGetBenchmarkNoCacheFlagDisablesCacheUsage(t *testing.T) {
+	root := t.TempDir()
+	configFile := filepath.Join(root, "aliae.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`cache: true
+alias:
+  - name: g
+    value: git
+`), 0o600))
+
+	previousConfig := config
+	previousNoCache := benchmarkNoCache
+	config = configFile
+	benchmarkNoCache = true
+	t.Cleanup(func() {
+		config = previousConfig
+		benchmarkNoCache = previousNoCache
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := getCmd.RunE(cmd, []string{"benchmark"})
+	require.NoError(t, err)
+	assert.Contains(t, stdout.String(), "benchmark.cache_used=false")
+	assert.Contains(t, stdout.String(), "benchmark.cygpath=")
+	assert.Contains(t, stdout.String(), "benchmark.validate_config=")
+	assert.NotContains(t, stdout.String(), "benchmark.validate_config=skipped")
 	assert.Empty(t, stderr.String())
 }
 

--- a/src/config/cache_bypass.go
+++ b/src/config/cache_bypass.go
@@ -1,0 +1,13 @@
+package config
+
+import "sync/atomic"
+
+var cacheBypass atomic.Bool
+
+func SetCacheBypass(disabled bool) {
+	cacheBypass.Store(disabled)
+}
+
+func isCacheBypassed() bool {
+	return cacheBypass.Load()
+}

--- a/src/config/cache_metrics.go
+++ b/src/config/cache_metrics.go
@@ -1,0 +1,13 @@
+package config
+
+import "sync/atomic"
+
+var lastLoadUsedCache atomic.Bool
+
+func setLastLoadUsedCache(value bool) {
+	lastLoadUsedCache.Store(value)
+}
+
+func LastLoadUsedCache() bool {
+	return lastLoadUsedCache.Load()
+}

--- a/src/config/cache_store.go
+++ b/src/config/cache_store.go
@@ -1,0 +1,158 @@
+package config
+
+import (
+	"crypto/sha256"
+	"encoding/gob"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"time"
+
+	aliaeState "github.com/jandedobbeleer/aliae/src/state"
+)
+
+const configCacheVersion = 1
+
+type configCacheEntry struct {
+	SchemaHash   string
+	CreatedAtUTC string
+	SourceFiles  []configCacheFile
+	Config       Aliae
+	Version      int
+	ComputeVars  bool
+}
+
+type configCacheFile struct {
+	Path         string
+	Size         int64
+	ModTimeNanos int64
+}
+
+func loadConfigCache(configPath string, computeVars bool) (*Aliae, bool, error) {
+	cachePath := configCachePath(configPath)
+	file, err := os.Open(cachePath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+	defer file.Close()
+
+	var entry configCacheEntry
+	if err := gob.NewDecoder(file).Decode(&entry); err != nil {
+		return nil, false, nil
+	}
+
+	if entry.Version != configCacheVersion || entry.SchemaHash != configSchemaHash() || entry.ComputeVars != computeVars {
+		return nil, false, nil
+	}
+
+	if !isConfigCacheValid(entry.SourceFiles) {
+		return nil, false, nil
+	}
+
+	cfg := entry.Config
+	return &cfg, true, nil
+}
+
+func storeConfigCache(configPath string, computeVars bool, inputs []string, aliae *Aliae) error {
+	if aliae == nil {
+		return nil
+	}
+
+	sourceFiles, err := fingerprintConfigFiles(inputs)
+	if err != nil {
+		return err
+	}
+
+	cachePath := configCachePath(configPath)
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o700); err != nil {
+		return err
+	}
+
+	file, err := os.Create(cachePath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	entry := configCacheEntry{
+		Version:      configCacheVersion,
+		SchemaHash:   configSchemaHash(),
+		ComputeVars:  computeVars,
+		Config:       *aliae,
+		SourceFiles:  sourceFiles,
+		CreatedAtUTC: time.Now().UTC().Format(time.RFC3339Nano),
+	}
+
+	return gob.NewEncoder(file).Encode(entry)
+}
+
+func configCachePath(configPath string) string {
+	sum := sha256.Sum256([]byte(filepath.Clean(configPath)))
+	fileName := fmt.Sprintf("config-cache-%s.gob", hex.EncodeToString(sum[:8]))
+	return aliaeState.Path(fileName)
+}
+
+func configSchemaHash() string {
+	sum := sha256.Sum256(configSchema)
+	return hex.EncodeToString(sum[:8])
+}
+
+func fingerprintConfigFiles(inputs []string) ([]configCacheFile, error) {
+	normalized := make([]string, 0, len(inputs))
+	seen := map[string]struct{}{}
+	for _, input := range inputs {
+		clean := filepath.Clean(strings.TrimSpace(input))
+		if clean == "" {
+			continue
+		}
+		if _, ok := seen[clean]; ok {
+			continue
+		}
+		seen[clean] = struct{}{}
+		normalized = append(normalized, clean)
+	}
+	slices.Sort(normalized)
+
+	files := make([]configCacheFile, 0, len(normalized))
+	for _, path := range normalized {
+		stat, err := os.Stat(path)
+		if err != nil {
+			return nil, err
+		}
+		files = append(files, configCacheFile{
+			Path:         path,
+			Size:         stat.Size(),
+			ModTimeNanos: stat.ModTime().UTC().UnixNano(),
+		})
+	}
+
+	return files, nil
+}
+
+func isConfigCacheValid(files []configCacheFile) bool {
+	if len(files) == 0 {
+		return false
+	}
+
+	for _, file := range files {
+		stat, err := os.Stat(file.Path)
+		if err != nil {
+			return false
+		}
+		if stat.Size() != file.Size {
+			return false
+		}
+		if stat.ModTime().UTC().UnixNano() != file.ModTimeNanos {
+			return false
+		}
+	}
+
+	return true
+}

--- a/src/config/cache_store_test.go
+++ b/src/config/cache_store_test.go
@@ -1,0 +1,45 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadConfigCacheCreatesAndInvalidates(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	root := t.TempDir()
+	configFile := filepath.Join(root, "aliae.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`cache: true
+alias:
+  - name: demo
+    value: one
+`), 0o600))
+
+	first, err := LoadConfig(configFile)
+	require.NoError(t, err)
+	require.Len(t, first.Aliae, 1)
+	assert.Equal(t, "one", string(first.Aliae[0].Value))
+	assert.True(t, first.Cache)
+
+	_, statErr := os.Stat(configCachePath(configFile))
+	assert.NoError(t, statErr)
+
+	time.Sleep(2 * time.Millisecond)
+	require.NoError(t, os.WriteFile(configFile, []byte(`cache: true
+alias:
+  - name: demo
+    value: two
+`), 0o600))
+
+	second, err := LoadConfig(configFile)
+	require.NoError(t, err)
+	require.Len(t, second.Aliae, 1)
+	assert.Equal(t, "two", string(second.Aliae[0].Value))
+	assert.True(t, second.Cache)
+}

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -50,9 +50,15 @@ func LoadConfigWithoutVars(configPath string) (*Aliae, error) {
 }
 
 func loadConfig(configPath string, computeVars bool) (*Aliae, error) {
+	setLastLoadUsedCache(false)
+
 	configPathCache = resolveConfigPath(configPath)
 	setTemplateConfigContext(configPathCache)
 	rootProgress, _ := loadRootProgress(configPathCache)
+	rootCache, _ := loadRootCache(configPathCache)
+	if isCacheBypassed() {
+		rootCache = false
+	}
 
 	if strings.HasPrefix(configPathCache, "http://") || strings.HasPrefix(configPathCache, "https://") {
 		aliae, err := getRemoteConfig(configPathCache, computeVars)
@@ -70,18 +76,39 @@ func loadConfig(configPath string, computeVars bool) (*Aliae, error) {
 
 		// progress.internal is root-only and must ignore included/extended sources.
 		aliae.Progress.Internal = rootProgress.Internal
+		aliae.Cache = rootCache
 		return aliae, nil
 	}
 
-	aliae, err := loadLocalConfig(configPathCache)
-	if err != nil {
-		return nil, err
-	}
-	if computeVars {
-		if err := aliae.computeVars(nil); err != nil {
-			return nil, err
+	var (
+		aliae      *Aliae
+		inputFiles []string
+		err        error
+	)
+
+	if rootCache {
+		cached, ok, cacheErr := loadConfigCache(configPathCache, computeVars)
+		if cacheErr == nil && ok {
+			aliae = cached
+			setLastLoadUsedCache(true)
 		}
 	}
+
+	if aliae == nil {
+		aliae, inputFiles, err = loadLocalConfigWithInputs(configPathCache)
+		if err != nil {
+			return nil, err
+		}
+		if computeVars {
+			if err := aliae.computeVars(nil); err != nil {
+				return nil, err
+			}
+		}
+		if rootCache {
+			_ = storeConfigCache(configPathCache, computeVars, inputFiles, aliae)
+		}
+	}
+
 	applyCygpathDefaults(aliae)
 	if err := validateCygpathMode(aliae); err != nil {
 		return nil, err
@@ -93,6 +120,7 @@ func loadConfig(configPath string, computeVars bool) (*Aliae, error) {
 
 	// progress.internal is root-only and must ignore included/extended sources.
 	aliae.Progress.Internal = rootProgress.Internal
+	aliae.Cache = rootCache
 	shell.SetStatTimeout(aliae.StatTimeout)
 
 	return aliae, nil

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -50,6 +50,7 @@ func TestLoadConfig(t *testing.T) {
 					{Name: "TEST_ENV", Value: "test"},
 				},
 				Cygpath: context.CygpathInternal,
+				Cache:   true,
 			},
 		},
 		{
@@ -67,6 +68,7 @@ func TestLoadConfig(t *testing.T) {
 					{Name: "test3", Value: shell.Template("test3")},
 				},
 				Cygpath: context.CygpathInternal,
+				Cache:   true,
 			},
 		},
 	}
@@ -120,6 +122,7 @@ func TestLoadConfigCygpathDefaultInternal(t *testing.T) {
 	aliae, err := LoadConfig(configFile)
 	assert.NoError(t, err)
 	assert.Equal(t, context.CygpathInternal, aliae.Cygpath)
+	assert.True(t, aliae.Cache)
 }
 
 func TestLoadConfigCygpathExternal(t *testing.T) {

--- a/src/config/extends.go
+++ b/src/config/extends.go
@@ -46,13 +46,13 @@ func (e extendsItem) shouldFailOnMissing() bool {
 	return e.FailOnMissing == nil || *e.FailOnMissing
 }
 
-func loadLocalConfig(configPath string) (*Aliae, error) {
+func loadLocalConfigWithInputs(configPath string) (*Aliae, []string, error) {
 	return loadLocalConfigRecursive(configPath, nil, 1)
 }
 
-func loadLocalConfigRecursive(configPath string, stack []string, depth int) (*Aliae, error) {
+func loadLocalConfigRecursive(configPath string, stack []string, depth int) (*Aliae, []string, error) {
 	if depth > maxExtendsDepth {
-		return nil, fmt.Errorf("extends depth limit exceeded: max %d", maxExtendsDepth)
+		return nil, nil, fmt.Errorf("extends depth limit exceeded: max %d", maxExtendsDepth)
 	}
 
 	absPath, err := filepath.Abs(configPath)
@@ -62,11 +62,11 @@ func loadLocalConfigRecursive(configPath string, stack []string, depth int) (*Al
 
 	absPath = filepath.Clean(absPath)
 	if slices.Contains(stack, absPath) {
-		return nil, fmt.Errorf("extends cycle detected for %s", absPath)
+		return nil, nil, fmt.Errorf("extends cycle detected for %s", absPath)
 	}
 
 	if stat, statErr := os.Stat(absPath); os.IsNotExist(statErr) || (statErr == nil && stat.IsDir()) {
-		return nil, fmt.Errorf("config file not found: %s", absPath)
+		return nil, nil, fmt.Errorf("config file not found: %s", absPath)
 	}
 
 	previousConfigPath := configPathCache
@@ -93,29 +93,30 @@ func loadLocalConfigRecursive(configPath string, stack []string, depth int) (*Al
 
 	data, err := os.ReadFile(absPath)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	includedData, err := includeUnmarshaler(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := validateScriptWeightsInYAML(includedData); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if err := validateScriptStateInYAML(includedData); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	extends, err := parseExtends(includedData)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if depth == 1 {
 		markInternalProgressDiscoveryComplete()
 	}
 
 	merged := &Aliae{}
+	inputs := []string{absPath}
 	nextStack := make([]string, len(stack)+1)
 	copy(nextStack, stack)
 	nextStack[len(stack)] = absPath
@@ -126,16 +127,17 @@ func loadLocalConfigRecursive(configPath string, stack []string, depth int) (*Al
 
 		paths, pathErr := resolveExtendsPaths(item, absPath)
 		if pathErr != nil {
-			return nil, pathErr
+			return nil, nil, pathErr
 		}
 
 		for _, path := range paths {
-			parent, loadErr := loadLocalConfigRecursive(path, nextStack, depth+1)
+			parent, parentInputs, loadErr := loadLocalConfigRecursive(path, nextStack, depth+1)
 			if loadErr != nil {
-				return nil, loadErr
+				return nil, nil, loadErr
 			}
 
 			merged.merge(parent)
+			inputs = append(inputs, parentInputs...)
 			if depth == 1 {
 				markInternalProgressLinkedConfigLoaded()
 			}
@@ -144,12 +146,12 @@ func loadLocalConfigRecursive(configPath string, stack []string, depth int) (*Al
 
 	current, err := decodeAliae(includedData)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	merged.merge(current)
 
-	return merged, nil
+	return merged, inputs, nil
 }
 
 func decodeAliae(data []byte) (*Aliae, error) {

--- a/src/config/extends_test.go
+++ b/src/config/extends_test.go
@@ -286,3 +286,27 @@ alias:
 	assert.Equal(t, 10.0, got.Progress.StartPercentage)
 	assert.Equal(t, 7.0, got.Progress.Internal)
 }
+
+func TestLoadConfigExtendsIgnoresCacheFromIncludedFiles(t *testing.T) {
+	root := t.TempDir()
+	base := filepath.Join(root, "base.yaml")
+	child := filepath.Join(root, "child.yaml")
+
+	require.NoError(t, os.WriteFile(base, []byte(`cache: true
+alias:
+  - name: base
+    value: from-base
+`), 0o600))
+
+	require.NoError(t, os.WriteFile(child, []byte(`extends:
+  - ./base.yaml
+cache: false
+alias:
+  - name: child
+    value: from-child
+`), 0o600))
+
+	got, err := LoadConfig(child)
+	require.NoError(t, err)
+	assert.False(t, got.Cache)
+}

--- a/src/config/progress_root.go
+++ b/src/config/progress_root.go
@@ -11,13 +11,8 @@ import (
 )
 
 func loadRootProgress(configPath string) (Progress, error) {
-	data, err := readRootConfigBytes(configPath)
+	document, err := loadRootConfigDocument(configPath)
 	if err != nil {
-		return Progress{}, err
-	}
-
-	document := map[string]any{}
-	if err := yaml.Unmarshal(data, &document); err != nil {
 		return Progress{}, err
 	}
 
@@ -27,6 +22,39 @@ func loadRootProgress(configPath string) (Progress, error) {
 	}
 
 	return parseProgressAny(progressValue)
+}
+
+func loadRootCache(configPath string) (bool, error) {
+	document, err := loadRootConfigDocument(configPath)
+	if err != nil {
+		return false, err
+	}
+
+	cacheValue, hasCache := document["cache"]
+	if !hasCache {
+		return true, nil
+	}
+
+	cache, ok := cacheValue.(bool)
+	if !ok {
+		return false, fmt.Errorf("cache must be a boolean")
+	}
+
+	return cache, nil
+}
+
+func loadRootConfigDocument(configPath string) (map[string]any, error) {
+	data, err := readRootConfigBytes(configPath)
+	if err != nil {
+		return nil, err
+	}
+
+	document := map[string]any{}
+	if err := yaml.Unmarshal(data, &document); err != nil {
+		return nil, err
+	}
+
+	return document, nil
 }
 
 func readRootConfigBytes(configPath string) ([]byte, error) {

--- a/src/config/schema.json
+++ b/src/config/schema.json
@@ -22,6 +22,11 @@
                 "external"
             ]
         },
+        "cache": {
+            "type": "boolean",
+            "default": true,
+            "description": "enable root-level merged+validated config cache to speed up subsequent runs."
+        },
         "progress": {
             "description": "automatic OSC progress output settings. Use false to disable.",
             "oneOf": [

--- a/src/config/unmarshal.go
+++ b/src/config/unmarshal.go
@@ -14,16 +14,17 @@ import (
 )
 
 type Aliae struct {
+	Cygpath     string        `yaml:"cygpath"`
 	Aliae       shell.Aliae   `yaml:"alias"`
 	Vars        Vars          `yaml:"var"`
 	Envs        shell.Envs    `yaml:"env"`
 	Paths       shell.Paths   `yaml:"path"`
 	CDPaths     shell.CDPaths `yaml:"cdpath"`
 	Scripts     shell.Scripts `yaml:"script"`
-	Cygpath     string        `yaml:"cygpath"`
 	Links       shell.Links   `yaml:"link"`
 	Progress    Progress      `yaml:"progress,omitempty"`
 	StatTimeout time.Duration `yaml:"stat_timeout"`
+	Cache       bool          `yaml:"cache,omitempty"`
 }
 
 type FuncMap []StringFunc

--- a/src/config/validate.go
+++ b/src/config/validate.go
@@ -457,6 +457,10 @@ func schemaDocument(aliae *Aliae) map[string]any {
 		document["cygpath"] = aliae.Cygpath
 	}
 
+	if aliae.Cache {
+		document["cache"] = true
+	}
+
 	return document
 }
 

--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -52,6 +52,7 @@ with emphasis on Git Bash compatibility and fork-owned release/documentation flo
   - `cdpath` support with shell-specific rendering and duplicate suppression.
 - Configuration capabilities:
   - Top-level `cygpath` mode (`internal` by default, `external` optional) to choose conversion backend.
+  - Top-level `cache` (enabled by default) to reuse merged+validated config when source files are unchanged.
   - Top-level `extends` with short/long syntax, cycle detection, and a depth limit.
   - Conditional `extends[].if` support to skip individual extends entries when false.
   - Top-level `progress` with weighted automatic OSC progress across `alias`, `env`, `path`, and `script`.

--- a/website/docs/setup/configuration.mdx
+++ b/website/docs/setup/configuration.mdx
@@ -26,6 +26,7 @@ The custom location can be a local file, or a URL pointing to a remote config.
 | -------------- | ------------- | ------------------------------------------------------------------ |
 | `stat_timeout` | `string`      | filesystem stat/existence timeout (default: `1s`, example `250ms`) |
 | `cygpath`      | `string`      | cygpath backend mode: `internal` (default) or `external`          |
+| `cache`        | `bool`        | enable root-level merged+validated config cache (default: `true`) |
 | `progress`     | `bool/object` | automatic OSC progress output (default: `false`)                  |
 | `var`          | `array`       | precomputed template variables exposed as `.Var.<Name>`           |
 <!-- markdownlint-enable MD060 -->
@@ -38,6 +39,8 @@ Set `internal` to reserve an initial span for internal init processing before sc
 `progress.internal` is read only from the root configuration file and is ignored in included or extended files.
 Internal progress OSC codes are written to `stderr`, allowing them to render before `eval`
 processes the init script from `stdout`.
+`cache` is read only from the root configuration file and is ignored in included or extended files.
+Set `cache: false` if you want to disable cache reuse.
 
 ## Example
 
@@ -45,6 +48,7 @@ processes the init script from `stdout`.
 # yaml-language-server: $schema=https://trajano.github.io/aliae/schema.json
 stat_timeout: 1s
 cygpath: internal
+cache: true
 progress:
   start_percentage: 21.44
   internal: 10

--- a/website/static/schema.json
+++ b/website/static/schema.json
@@ -22,6 +22,11 @@
                 "external"
             ]
         },
+        "cache": {
+            "type": "boolean",
+            "default": true,
+            "description": "enable root-level merged+validated config cache to speed up subsequent runs."
+        },
         "progress": {
             "description": "automatic OSC progress output settings. Use false to disable.",
             "oneOf": [


### PR DESCRIPTION
## Summary
- add root-only merged config cache pipeline with metadata invalidation and binary cache storage
- make top-level `cache` default to enabled when omitted (root config only)
- add benchmark controls: `--no-cache`, `benchmark.cache_used`, `benchmark.cygpath`, and conditional `validate_config` timing
- update config schema/docs to reflect cache behavior and defaults

## Validation
- cd src && go fmt ./...
- cd src && go mod tidy
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
- cd src && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
- cd src && "$(go env GOPATH)"/bin/fieldalignment ./...
- cd website && npm ci && npm run build

## Notes
- markdownlint currently reports pre-existing repo-wide issues outside this PR scope.
