### PR TITLE
fix: reevaluate runtime vars and extends conditions with cache

### DIFF
--- a/src/config/cache_store_test.go
+++ b/src/config/cache_store_test.go
@@ -3,9 +3,11 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
+	"github.com/jandedobbeleer/aliae/src/shell"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -42,4 +44,68 @@ alias:
 	require.Len(t, second.Aliae, 1)
 	assert.Equal(t, "two", string(second.Aliae[0].Value))
 	assert.True(t, second.Cache)
+}
+
+func TestLoadConfigCacheReevaluatesConditionalExtends(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	root := t.TempDir()
+	base := filepath.Join(root, "base.yaml")
+	configFile := filepath.Join(root, "aliae.yaml")
+	require.NoError(t, os.WriteFile(base, []byte(`alias:
+  - name: base
+    value: base
+`), 0o600))
+	require.NoError(t, os.WriteFile(configFile, []byte(`cache: true
+extends:
+  - path: ./base.yaml
+    if: hasCommandNoCache "aliae-cache-volatile-cmd"
+alias:
+  - name: child
+    value: child
+`), 0o600))
+
+	first := Init(configFile, shell.BASH, true)
+	assert.NotContains(t, first, `alias base="base"`)
+	assert.Contains(t, first, `alias child="child"`)
+
+	originalPath := os.Getenv("PATH")
+	tempDir := t.TempDir()
+	commandFile := filepath.Join(tempDir, "aliae-cache-volatile-cmd")
+	content := []byte("#!/bin/sh\nexit 0\n")
+	if runtime.GOOS == "windows" {
+		commandFile += ".cmd"
+		content = []byte("@echo off\r\nexit /b 0\r\n")
+	}
+	require.NoError(t, os.WriteFile(commandFile, content, 0o700))
+	require.NoError(t, os.Setenv("PATH", tempDir+string(os.PathListSeparator)+originalPath))
+
+	second := Init(configFile, shell.BASH, true)
+	assert.Contains(t, second, `alias base="base"`)
+	assert.Contains(t, second, `alias child="child"`)
+}
+
+func TestLoadConfigCacheRecomputesVarsOnCacheHit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	root := t.TempDir()
+	configFile := filepath.Join(root, "aliae.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`cache: true
+var:
+  - name: ENABLED
+    value: true
+env:
+  - name: CACHE_VAR_TEST
+    value: ok
+    if: .Var.ENABLED
+`), 0o600))
+
+	first := Init(configFile, shell.BASH, true)
+	assert.Contains(t, first, `export CACHE_VAR_TEST="ok"`)
+	assert.False(t, LastLoadUsedCache())
+
+	shell.DotFile.Reset()
+	second := Init(configFile, shell.BASH, true)
+	assert.Contains(t, second, `export CACHE_VAR_TEST="ok"`)
+	assert.True(t, LastLoadUsedCache())
 }

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -90,6 +90,11 @@ func loadConfig(configPath string, computeVars bool) (*Aliae, error) {
 		cached, ok, cacheErr := loadConfigCache(configPathCache, computeVars)
 		if cacheErr == nil && ok {
 			aliae = cached
+			if computeVars {
+				if err := aliae.computeVars(nil); err != nil {
+					return nil, err
+				}
+			}
 			setLastLoadUsedCache(true)
 		}
 	}

--- a/src/config/extends.go
+++ b/src/config/extends.go
@@ -121,10 +121,6 @@ func loadLocalConfigRecursive(configPath string, stack []string, depth int) (*Al
 	copy(nextStack, stack)
 	nextStack[len(stack)] = absPath
 	for _, item := range extends {
-		if item.If.Ignore() {
-			continue
-		}
-
 		paths, pathErr := resolveExtendsPaths(item, absPath)
 		if pathErr != nil {
 			return nil, nil, pathErr
@@ -135,6 +131,7 @@ func loadLocalConfigRecursive(configPath string, stack []string, depth int) (*Al
 			if loadErr != nil {
 				return nil, nil, loadErr
 			}
+			parent = applyExtendsCondition(parent, item.If)
 
 			merged.merge(parent)
 			inputs = append(inputs, parentInputs...)
@@ -310,4 +307,77 @@ func (a *Aliae) merge(other *Aliae) {
 	if other.Progress.Enabled || other.Progress.EndPercentage.Reset || other.Progress.EndPercentage.Value > 0 || other.Progress.StartPercentage > 0 {
 		a.Progress = other.Progress
 	}
+}
+
+func applyExtendsCondition(aliae *Aliae, condition shell.If) *Aliae {
+	if aliae == nil {
+		return nil
+	}
+
+	if strings.TrimSpace(string(condition)) == "" {
+		return aliae
+	}
+
+	for _, alias := range aliae.Aliae {
+		if alias == nil {
+			continue
+		}
+		alias.If = andIf(alias.If, condition)
+	}
+
+	for _, variable := range aliae.Vars {
+		if variable == nil {
+			continue
+		}
+		variable.If = andIf(variable.If, condition)
+	}
+
+	for _, env := range aliae.Envs {
+		if env == nil {
+			continue
+		}
+		env.If = andIf(env.If, condition)
+	}
+
+	for _, path := range aliae.Paths {
+		if path == nil {
+			continue
+		}
+		path.If = andIf(path.If, condition)
+	}
+
+	for _, cdpath := range aliae.CDPaths {
+		if cdpath == nil {
+			continue
+		}
+		cdpath.If = andIf(cdpath.If, condition)
+	}
+
+	for _, script := range aliae.Scripts {
+		if script == nil {
+			continue
+		}
+		script.If = andIf(script.If, condition)
+	}
+
+	for _, link := range aliae.Links {
+		if link == nil {
+			continue
+		}
+		link.If = andIf(link.If, condition)
+	}
+
+	return aliae
+}
+
+func andIf(existing, condition shell.If) shell.If {
+	if strings.TrimSpace(string(existing)) == "" {
+		return condition
+	}
+
+	if strings.TrimSpace(string(condition)) == "" {
+		return existing
+	}
+
+	return shell.If(fmt.Sprintf("and (%s) (%s)", condition, existing))
 }

--- a/src/config/extends_test.go
+++ b/src/config/extends_test.go
@@ -86,6 +86,7 @@ alias:
 	got, err := LoadConfig(child)
 	require.NoError(t, err)
 	assert.Equal(t, shell.Aliae{
+		{Name: "base", Value: shell.Template("from-base"), If: shell.If("false")},
 		{Name: "child", Value: shell.Template("from-child")},
 	}, got.Aliae)
 }
@@ -110,7 +111,7 @@ alias:
 	got, err := LoadConfig(child)
 	require.NoError(t, err)
 	assert.Equal(t, shell.Aliae{
-		{Name: "base", Value: shell.Template("from-base")},
+		{Name: "base", Value: shell.Template("from-base"), If: shell.If("true")},
 		{Name: "child", Value: shell.Template("from-child")},
 	}, got.Aliae)
 }

--- a/src/config/init_test.go
+++ b/src/config/init_test.go
@@ -349,6 +349,28 @@ alias:
 	assert.Contains(t, script, `alias tools="echo tools"`)
 }
 
+func TestInitTopLevelVarBooleanFalseIsFalseInIf(t *testing.T) {
+	shell.DotFile.Reset()
+	t.Cleanup(shell.DotFile.Reset)
+
+	tempDir := t.TempDir()
+	configFile := filepath.ToSlash(filepath.Join(tempDir, "aliae.yaml"))
+	configContent := `var:
+  - name: ENABLE_ALIAS
+    value: eq 1 2
+alias:
+  - name: tools
+    value: echo tools
+    if: .Var.ENABLE_ALIAS
+`
+
+	err := os.WriteFile(configFile, []byte(configContent), 0o600)
+	assert.NoError(t, err)
+
+	script := Init(configFile, shell.BASH, true)
+	assert.NotContains(t, script, `alias tools="echo tools"`)
+}
+
 func TestInitInternalProgressIncludesVarComputation(t *testing.T) {
 	shell.DotFile.Reset()
 	t.Cleanup(shell.DotFile.Reset)

--- a/src/config/var.go
+++ b/src/config/var.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/jandedobbeleer/aliae/src/context"
@@ -29,14 +30,14 @@ func (a *Aliae) computeVars(lineResolver *yamlLineResolver) error {
 	ctx := ensureTemplateRuntime()
 
 	if ctx.Var == nil {
-		ctx.Var = map[string]string{}
+		ctx.Var = map[string]any{}
 	}
 
 	if err := validateVarDefinitions(a.Vars, lineResolver); err != nil {
 		return err
 	}
 
-	computed := make(map[string]string, len(a.Vars))
+	computed := make(map[string]any, len(a.Vars))
 	ctx.Var = computed
 
 	for _, variable := range a.Vars {
@@ -52,14 +53,14 @@ func (a *Aliae) computeVars(lineResolver *yamlLineResolver) error {
 	return nil
 }
 
-func evaluateVarValue(value shell.Template) string {
+func evaluateVarValue(value shell.Template) any {
 	text := strings.TrimSpace(string(value))
 	if len(text) == 0 {
 		return ""
 	}
 
 	if strings.Contains(text, "{{") && strings.Contains(text, "}}") {
-		return value.String()
+		return normalizeVarValue(value.String())
 	}
 
 	// Allow `var.value` to behave like `if`, where bare expressions are valid.
@@ -68,7 +69,17 @@ func evaluateVarValue(value shell.Template) string {
 		return text
 	}
 
-	return parsed
+	return normalizeVarValue(parsed)
+}
+
+func normalizeVarValue(value string) any {
+	trimmed := strings.TrimSpace(value)
+	parsedBool, err := strconv.ParseBool(trimmed)
+	if err == nil {
+		return parsedBool
+	}
+
+	return value
 }
 
 func ensureTemplateRuntime() *context.Runtime {
@@ -81,7 +92,7 @@ func ensureTemplateRuntime() *context.Runtime {
 		OS:    context.LINUX,
 		Home:  context.Home(),
 		Env:   map[string]string{},
-		Var:   map[string]string{},
+		Var:   map[string]any{},
 	}
 
 	return context.Current

--- a/src/context/runtime.go
+++ b/src/context/runtime.go
@@ -16,7 +16,7 @@ type Runtime struct {
 	Path       *Path
 	CDPath     *Path
 	Env        map[string]string
-	Var        map[string]string
+	Var        map[string]any
 	Shell      string
 	OS         string
 	Hostname   string
@@ -40,7 +40,7 @@ func Init(shell string) {
 		Home:     home,
 		Hostname: hostname,
 		Env:      getEnvironment(),
-		Var:      map[string]string{},
+		Var:      map[string]any{},
 		Cygpath:  CygpathInternal,
 	}
 


### PR DESCRIPTION
## Summary
- recompute top-level `var` values on cache hits so `.Var.*` conditions remain accurate
- preserve boolean var values as typed booleans to avoid treating `"false"` as truthy
- evaluate `extends.if` at runtime by attaching the condition to merged entries instead of pruning during load

## Tests
- go fmt ./...
- go mod tidy
- go test ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
- go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
- "$(go env GOPATH)"/bin/fieldalignment ./...
