### PR TITLE
fix(config): isolate cache entries by shell context

### DIFF
--- a/src/config/cache_store.go
+++ b/src/config/cache_store.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jandedobbeleer/aliae/src/context"
 	aliaeState "github.com/jandedobbeleer/aliae/src/state"
 )
 
@@ -94,9 +95,18 @@ func storeConfigCache(configPath string, computeVars bool, inputs []string, alia
 }
 
 func configCachePath(configPath string) string {
-	sum := sha256.Sum256([]byte(filepath.Clean(configPath)))
+	key := filepath.Clean(configPath) + "|" + cacheContextKey()
+	sum := sha256.Sum256([]byte(key))
 	fileName := fmt.Sprintf("config-cache-%s.gob", hex.EncodeToString(sum[:8]))
 	return aliaeState.Path(fileName)
+}
+
+func cacheContextKey() string {
+	if context.Current == nil {
+		return "shell=;os=;wsl=false"
+	}
+
+	return fmt.Sprintf("shell=%s;os=%s;wsl=%t", context.Current.Shell, context.Current.OS, context.Current.WSL)
 }
 
 func configSchemaHash() string {

--- a/src/config/cache_store_test.go
+++ b/src/config/cache_store_test.go
@@ -109,3 +109,36 @@ env:
 	assert.Contains(t, second, `export CACHE_VAR_TEST="ok"`)
 	assert.True(t, LastLoadUsedCache())
 }
+
+func TestLoadConfigCacheSeparatesConditionalExtendsByShell(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	root := t.TempDir()
+	bashConfig := filepath.Join(root, "bash.yml")
+	pwshConfig := filepath.Join(root, "pwsh.yml")
+	configFile := filepath.Join(root, "aliae.yaml")
+
+	require.NoError(t, os.WriteFile(bashConfig, []byte(`script:
+  - value: echo bash-only
+`), 0o600))
+	require.NoError(t, os.WriteFile(pwshConfig, []byte(`script:
+  - value: Write-Host pwsh-only
+`), 0o600))
+	require.NoError(t, os.WriteFile(configFile, []byte(`cache: true
+extends:
+  - path: ./bash.yml
+    if: eq .Shell "bash"
+  - path: ./pwsh.yml
+    if: eq .Shell "pwsh"
+`), 0o600))
+
+	bashInit := Init(configFile, shell.BASH, true)
+	assert.Contains(t, bashInit, "echo bash-only")
+	assert.NotContains(t, bashInit, "Write-Host pwsh-only")
+	assert.False(t, LastLoadUsedCache())
+
+	pwshInit := Init(configFile, shell.PWSH, true)
+	assert.Contains(t, pwshInit, "Write-Host pwsh-only")
+	assert.NotContains(t, pwshInit, "echo bash-only")
+	assert.False(t, LastLoadUsedCache())
+}


### PR DESCRIPTION
## Summary
- make config cache key runtime-aware so cache entries are isolated by shell context
- include shell/OS/WSL fingerprint in cache path key derivation
- add regression test that reproduces bash->pwsh stale cache contamination and verifies separation

## Why
Switching between `bash` and `pwsh` on the same config path could previously reuse a merged extends result from the wrong shell, which leaked shell-specific scripts (for example `trap`) into PowerShell output.

## Validation
- cd src && go fmt ./...
- cd src && go mod tidy
- cd src && go test ./...
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
- cd src && "$(go env GOPATH)"/bin/fieldalignment ./...
