### PR TITLE
perf(init): allow render cache when state scripts are not due

### DIFF
--- a/src/init/render_cache.go
+++ b/src/init/render_cache.go
@@ -54,7 +54,10 @@ type renderCacheEntry struct {
 }
 
 func prepareRenderCache(configPath, sh string, aliae *cfg.Aliae) *renderCacheState {
-	if aliae == nil || hasStatefulScripts(aliae) {
+	if aliae == nil {
+		return nil
+	}
+	if !isStateCacheEligible(aliae, time.Now()) {
 		return nil
 	}
 
@@ -293,17 +296,33 @@ func hashTrackedEnv(runtime *context.Runtime, keys []string) string {
 	return hex.EncodeToString(sum.Sum(nil))
 }
 
-func hasStatefulScripts(aliae *cfg.Aliae) bool {
+func isStateCacheEligible(aliae *cfg.Aliae, now time.Time) bool {
 	if aliae == nil {
+		return true
+	}
+
+	references, err := aliae.Scripts.StateReferences()
+	if err != nil {
 		return false
 	}
-	for _, script := range aliae.Scripts {
-		if script == nil {
+	if len(references) == 0 {
+		return true
+	}
+
+	for _, reference := range references {
+		if strings.TrimSpace(reference.File) == "" {
 			continue
 		}
-		if strings.TrimSpace(string(script.State.File)) != "" {
-			return true
+
+		statePath := aliaeState.Path(reference.File)
+		shouldRun, _, checkErr := aliaeState.ShouldRun(statePath, reference.RunEvery, now)
+		if checkErr != nil {
+			return false
+		}
+		if shouldRun {
+			return false
 		}
 	}
-	return false
+
+	return true
 }

--- a/src/init/render_cache_test.go
+++ b/src/init/render_cache_test.go
@@ -4,9 +4,12 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	cfg "github.com/jandedobbeleer/aliae/src/config"
+	"github.com/jandedobbeleer/aliae/src/context"
 	"github.com/jandedobbeleer/aliae/src/shell"
+	aliaeState "github.com/jandedobbeleer/aliae/src/state"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -37,7 +40,39 @@ env:
 	assert.Contains(t, second, `export RENDER_CACHE_ENV="two"`)
 }
 
-func TestInitRenderCacheSkippedForStatefulScripts(t *testing.T) {
+func TestInitRenderCacheStatefulScriptsUseCacheWhenNotDue(t *testing.T) {
+	context.SetCurrent(nil)
+	t.Setenv("HOME", t.TempDir())
+
+	configFile := filepath.ToSlash(filepath.Join(t.TempDir(), "aliae.yaml"))
+	require.NoError(t, os.WriteFile(configFile, []byte(`cache: true
+env:
+  - name: CACHE_SENTINEL
+    value: ok
+script:
+  - value: echo once
+    state:
+      file: run-once.state
+`), 0o600))
+
+	statePath := aliaeState.Path("run-once.state")
+	require.NoError(t, os.MkdirAll(filepath.Dir(statePath), 0o700))
+	require.NoError(t, os.WriteFile(statePath, []byte("ok"), 0o600))
+	timestamp := time.Now().UTC()
+	require.NoError(t, os.Chtimes(statePath, timestamp, timestamp))
+
+	_ = Init(configFile, shell.BASH, true)
+
+	aliae, err := cfg.LoadConfig(configFile)
+	require.NoError(t, err)
+	cacheState := prepareRenderCache(configFile, shell.BASH, aliae)
+	require.NotNil(t, cacheState)
+	_, statErr := os.Stat(cacheState.entryPath)
+	require.NoError(t, statErr)
+}
+
+func TestInitRenderCacheStatefulScriptsSkipCacheWhenDue(t *testing.T) {
+	context.SetCurrent(nil)
 	t.Setenv("HOME", t.TempDir())
 
 	configFile := filepath.ToSlash(filepath.Join(t.TempDir(), "aliae.yaml"))
@@ -47,8 +82,6 @@ script:
     state:
       file: run-once.state
 `), 0o600))
-
-	_ = Init(configFile, shell.BASH, true)
 
 	aliae, err := cfg.LoadConfig(configFile)
 	require.NoError(t, err)


### PR DESCRIPTION
## Summary\n- keep rendered init cache enabled when stateful scripts are currently not due to run\n- evaluate state references up front and only bypass cache when any state file indicates a run is needed\n- add tests for both cache-eligible and cache-bypass stateful scenarios\n\n## Validation\n- cd src && go fmt ./...\n- cd src && go test ./...\n- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run\n- cd src && fieldalignment ./...