### PR TITLE
feat(nu)!: import vendor autoload init from upstream

### DIFF
--- a/src/.golangci.yml
+++ b/src/.golangci.yml
@@ -49,6 +49,10 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - goconst
     paths:
       - third_party$
       - builtin$

--- a/src/appcmd/get.go
+++ b/src/appcmd/get.go
@@ -54,6 +54,14 @@ type BenchmarkCommand struct {
 	NoCache        bool
 }
 
+const (
+	yamlKeyForce    = "force"
+	yamlKeyIfExists = "ifExists"
+	yamlKeyName     = "name"
+	yamlKeyType     = "type"
+	yamlKeyValue    = "value"
+)
+
 func (c BenchmarkCommand) Execute() error {
 	return printBenchmark(c.Out, c.ConfigPath, c.BenchmarkShell, c.NoCache)
 }
@@ -108,16 +116,16 @@ func toAliasOutput(items shell.Aliae) []yaml.MapSlice {
 			continue
 		}
 
-		item := yaml.MapSlice{{Key: "name", Value: alias.Name}}
+		item := yaml.MapSlice{{Key: yamlKeyName, Value: alias.Name}}
 		if len(alias.Type) > 0 {
-			item = append(item, yaml.MapItem{Key: "type", Value: alias.Type})
+			item = append(item, yaml.MapItem{Key: yamlKeyType, Value: alias.Type})
 		}
-		item = append(item, yaml.MapItem{Key: "value", Value: alias.Value})
+		item = append(item, yaml.MapItem{Key: yamlKeyValue, Value: alias.Value})
 		if len(alias.Description) > 0 {
 			item = append(item, yaml.MapItem{Key: "description", Value: alias.Description})
 		}
 		if alias.Force {
-			item = append(item, yaml.MapItem{Key: "force", Value: true})
+			item = append(item, yaml.MapItem{Key: yamlKeyForce, Value: true})
 		}
 		if len(alias.If) > 0 {
 			item = append(item, yaml.MapItem{Key: "if", Value: alias.If})
@@ -142,11 +150,11 @@ func toEnvOutput(items shell.Envs) []yaml.MapSlice {
 			continue
 		}
 
-		item := yaml.MapSlice{{Key: "name", Value: env.Name}}
+		item := yaml.MapSlice{{Key: yamlKeyName, Value: env.Name}}
 		if len(env.Type) > 0 {
-			item = append(item, yaml.MapItem{Key: "type", Value: env.Type})
+			item = append(item, yaml.MapItem{Key: yamlKeyType, Value: env.Type})
 		}
-		item = append(item, yaml.MapItem{Key: "value", Value: env.Value})
+		item = append(item, yaml.MapItem{Key: yamlKeyValue, Value: env.Value})
 		if len(env.Delimiter) > 0 {
 			item = append(item, yaml.MapItem{Key: "delimiter", Value: env.Delimiter})
 		}
@@ -154,7 +162,7 @@ func toEnvOutput(items shell.Envs) []yaml.MapSlice {
 			item = append(item, yaml.MapItem{Key: "if", Value: env.If})
 		}
 		if env.IfExists {
-			item = append(item, yaml.MapItem{Key: "ifExists", Value: true})
+			item = append(item, yaml.MapItem{Key: yamlKeyIfExists, Value: true})
 		}
 		if env.IsPath {
 			item = append(item, yaml.MapItem{Key: "isPath", Value: true})
@@ -177,8 +185,8 @@ func toVarOutput(items cfg.Vars) []yaml.MapSlice {
 		}
 
 		item := yaml.MapSlice{
-			{Key: "name", Value: variable.Name},
-			{Key: "value", Value: variable.Value},
+			{Key: yamlKeyName, Value: variable.Name},
+			{Key: yamlKeyValue, Value: variable.Value},
 		}
 		if len(variable.If) > 0 {
 			item = append(item, yaml.MapItem{Key: "if", Value: variable.If})
@@ -197,15 +205,15 @@ func toPathOutput(items shell.Paths) []yaml.MapSlice {
 			continue
 		}
 
-		entry := yaml.MapSlice{{Key: "value", Value: item.Value}}
+		entry := yaml.MapSlice{{Key: yamlKeyValue, Value: item.Value}}
 		if item.Force {
-			entry = append(entry, yaml.MapItem{Key: "force", Value: true})
+			entry = append(entry, yaml.MapItem{Key: yamlKeyForce, Value: true})
 		}
 		if len(item.If) > 0 {
 			entry = append(entry, yaml.MapItem{Key: "if", Value: item.If})
 		}
 		if item.IfExists {
-			entry = append(entry, yaml.MapItem{Key: "ifExists", Value: true})
+			entry = append(entry, yaml.MapItem{Key: yamlKeyIfExists, Value: true})
 		}
 		if item.Persist {
 			entry = append(entry, yaml.MapItem{Key: "persist", Value: true})
@@ -224,15 +232,15 @@ func toCDPathOutput(items shell.CDPaths) []yaml.MapSlice {
 			continue
 		}
 
-		entry := yaml.MapSlice{{Key: "value", Value: item.Value}}
+		entry := yaml.MapSlice{{Key: yamlKeyValue, Value: item.Value}}
 		if item.Force {
-			entry = append(entry, yaml.MapItem{Key: "force", Value: true})
+			entry = append(entry, yaml.MapItem{Key: yamlKeyForce, Value: true})
 		}
 		if len(item.If) > 0 {
 			entry = append(entry, yaml.MapItem{Key: "if", Value: item.If})
 		}
 		if item.IfExists {
-			entry = append(entry, yaml.MapItem{Key: "ifExists", Value: true})
+			entry = append(entry, yaml.MapItem{Key: yamlKeyIfExists, Value: true})
 		}
 
 		output = append(output, entry)
@@ -248,9 +256,9 @@ func toScriptOutput(items shell.Scripts) []yaml.MapSlice {
 			continue
 		}
 
-		entry := yaml.MapSlice{{Key: "value", Value: script.Value}}
+		entry := yaml.MapSlice{{Key: yamlKeyValue, Value: script.Value}}
 		if len(script.Type) > 0 {
-			entry = append(entry, yaml.MapItem{Key: "type", Value: script.Type})
+			entry = append(entry, yaml.MapItem{Key: yamlKeyType, Value: script.Type})
 		}
 		if len(script.If) > 0 {
 			entry = append(entry, yaml.MapItem{Key: "if", Value: script.If})
@@ -283,7 +291,7 @@ func toLinkOutput(items shell.Links) []yaml.MapSlice {
 		}
 
 		entry := yaml.MapSlice{
-			{Key: "name", Value: item.Name},
+			{Key: yamlKeyName, Value: item.Name},
 			{Key: "target", Value: item.Target},
 		}
 		if len(item.If) > 0 {

--- a/src/cli/get.go
+++ b/src/cli/get.go
@@ -11,6 +11,13 @@ import (
 // getCmd represents the get command
 var getCmd = newGetCommand()
 
+const (
+	getArgBenchmark = "benchmark"
+	getArgConfig    = "config"
+	getArgShell     = "shell"
+	getArgVariables = "variables"
+)
+
 func newGetCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "get [shell|config|variables|benchmark [shell]]",
@@ -24,27 +31,27 @@ This command is used to get the value of the following variables:
 - variables
 - benchmark [shell]`,
 		ValidArgs: []string{
-			"shell",
-			"config",
-			"variables",
-			"benchmark",
+			getArgShell,
+			getArgConfig,
+			getArgVariables,
+			getArgBenchmark,
 		},
 		Args: validateGetArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			switch args[0] {
-			case "shell":
+			case getArgShell:
 				return appcmd.GetShellCommand{Out: cmd.OutOrStdout()}.Execute()
-			case "config":
+			case getArgConfig:
 				return appcmd.GetResolvedConfigCommand{
 					ConfigPath: config,
 					Out:        cmd.OutOrStdout(),
 				}.Execute()
-			case "variables":
+			case getArgVariables:
 				return appcmd.GetVariablesCommand{
 					ConfigPath: config,
 					Out:        cmd.OutOrStdout(),
 				}.Execute()
-			case "benchmark":
+			case getArgBenchmark:
 				benchmarkShell := ""
 				if len(args) == 2 {
 					benchmarkShell = args[1]
@@ -77,12 +84,12 @@ func validateGetArgs(_ *cobra.Command, args []string) error {
 	}
 
 	switch args[0] {
-	case "shell", "config", "variables":
+	case getArgShell, getArgConfig, getArgVariables:
 		if len(args) != 1 {
 			return fmt.Errorf("%s does not accept extra arguments", args[0])
 		}
 		return nil
-	case "benchmark":
+	case getArgBenchmark:
 		if len(args) == 1 {
 			return nil
 		}

--- a/src/cli/init.go
+++ b/src/cli/init.go
@@ -4,6 +4,7 @@ import (
 	"os"
 
 	"github.com/jandedobbeleer/aliae/src/appcmd"
+	"github.com/jandedobbeleer/aliae/src/shell"
 	"github.com/spf13/cobra"
 	"golang.org/x/term"
 )
@@ -15,6 +16,18 @@ var (
 	initCmd = newInitCommand()
 )
 
+var initValidArgs = []string{
+	shell.BASH,
+	shell.ZSH,
+	shell.FISH,
+	shell.PWSH,
+	shell.POWERSHELL,
+	shell.CMD,
+	shell.NU,
+	shell.TCSH,
+	shell.XONSH,
+}
+
 func newInitCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "init [bash|zsh|fish|pwsh|powershell|cmd|nu|tcsh|xonsh]",
@@ -23,18 +36,8 @@ func newInitCommand() *cobra.Command {
 
 See the documentation to initialize your shell: https://trajano.github.io/aliae/docs/setup/shell.
 This is a personal fork. For the official project and docs, see https://aliae.dev.`,
-		ValidArgs: []string{
-			"bash",
-			"zsh",
-			"fish",
-			"pwsh",
-			"powershell",
-			"cmd",
-			"nu",
-			"tcsh",
-			"xonsh",
-		},
-		Args: NoArgsOrOneValidArg,
+		ValidArgs: initValidArgs,
+		Args:      NoArgsOrOneValidArg,
 		Run: func(cmd *cobra.Command, args []string) {
 			if len(args) == 0 {
 				_ = cmd.Help()

--- a/src/config/schema_builder.go
+++ b/src/config/schema_builder.go
@@ -16,6 +16,11 @@ type schemaBuilder struct {
 	links   []map[string]any
 }
 
+const (
+	schemaKeyName  = "name"
+	schemaKeyValue = "value"
+)
+
 func buildSchemaDocument(aliae *Aliae) map[string]any {
 	document := make(map[string]any)
 	if aliae == nil {
@@ -99,8 +104,8 @@ func buildSchemaDocument(aliae *Aliae) map[string]any {
 
 func varSchemaItem(variable *Var) map[string]any {
 	item := map[string]any{
-		"name":  variable.Name,
-		"value": string(variable.Value),
+		schemaKeyName:  variable.Name,
+		schemaKeyValue: string(variable.Value),
 	}
 	if len(variable.If) > 0 {
 		item["if"] = string(variable.If)
@@ -110,8 +115,8 @@ func varSchemaItem(variable *Var) map[string]any {
 
 func aliasSchemaItem(alias *shell.Alias) map[string]any {
 	item := map[string]any{
-		"name":  alias.Name,
-		"value": string(alias.Value),
+		schemaKeyName:  alias.Name,
+		schemaKeyValue: string(alias.Value),
 	}
 	if len(alias.Type) > 0 {
 		item["type"] = string(alias.Type)
@@ -124,8 +129,8 @@ func aliasSchemaItem(alias *shell.Alias) map[string]any {
 
 func envSchemaItem(env *shell.Env) map[string]any {
 	item := map[string]any{
-		"name":  env.Name,
-		"value": env.Value,
+		schemaKeyName:  env.Name,
+		schemaKeyValue: env.Value,
 	}
 	if len(env.Delimiter) > 0 {
 		item["delimiter"] = string(env.Delimiter)
@@ -150,7 +155,7 @@ func envSchemaItem(env *shell.Env) map[string]any {
 
 func pathSchemaItem(path *shell.Path) map[string]any {
 	item := map[string]any{
-		"value": string(path.Value),
+		schemaKeyValue: string(path.Value),
 	}
 	if len(path.If) > 0 {
 		item["if"] = string(path.If)
@@ -169,7 +174,7 @@ func pathSchemaItem(path *shell.Path) map[string]any {
 
 func cdpathSchemaItem(path *shell.CDPath) map[string]any {
 	item := map[string]any{
-		"value": string(path.Value),
+		schemaKeyValue: string(path.Value),
 	}
 	if len(path.If) > 0 {
 		item["if"] = string(path.If)
@@ -185,7 +190,7 @@ func cdpathSchemaItem(path *shell.CDPath) map[string]any {
 
 func scriptSchemaItem(script *shell.Script) map[string]any {
 	item := map[string]any{
-		"value": string(script.Value),
+		schemaKeyValue: string(script.Value),
 	}
 	if len(script.Type) > 0 {
 		item["type"] = string(script.Type)
@@ -213,8 +218,8 @@ func scriptSchemaItem(script *shell.Script) map[string]any {
 
 func linkSchemaItem(link *shell.Link) map[string]any {
 	item := map[string]any{
-		"name":   string(link.Name),
-		"target": string(link.Target),
+		schemaKeyName: string(link.Name),
+		"target":      string(link.Target),
 	}
 	if len(link.If) > 0 {
 		item["if"] = string(link.If)

--- a/src/context/os.go
+++ b/src/context/os.go
@@ -14,7 +14,7 @@ func isMSYS2Shell() bool {
 		return false
 	}
 
-	return current.OS == WINDOWS && current.Shell == "bash" && os.Getenv("MSYSTEM") != ""
+	return current.OS == WINDOWS && current.Shell == shellBash && os.Getenv("MSYSTEM") != ""
 }
 
 func PathDelimiter() string {

--- a/src/context/path_test.go
+++ b/src/context/path_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestPathDelimiterWindowsMSYS2(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "bash"})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellBash})
 
 	assert.Equal(t, ":", PathDelimiter())
 	assert.Equal(t, "/", PathSeparator())
@@ -17,7 +17,7 @@ func TestPathDelimiterWindowsMSYS2(t *testing.T) {
 
 func TestPathDelimiterWindowsNonMSYS2(t *testing.T) {
 	t.Setenv("MSYSTEM", "")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "pwsh"})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellPwsh})
 
 	assert.Equal(t, ";", PathDelimiter())
 	assert.Equal(t, "\\", PathSeparator())
@@ -26,7 +26,7 @@ func TestPathDelimiterWindowsNonMSYS2(t *testing.T) {
 func TestPathContainsEquivalentWindowsAndMSYS2Forms(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
 	t.Setenv("PATH", "")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "bash", Cygpath: CygpathInternal})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellBash, Cygpath: CygpathInternal})
 	clearCleanPathCache()
 	t.Cleanup(clearCleanPathCache)
 
@@ -41,7 +41,7 @@ func TestPathContainsEquivalentWindowsAndMSYS2Forms(t *testing.T) {
 
 func TestSplitPathEntriesWindowsMSYS2MixedDelimiters(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "bash"})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellBash})
 
 	paths := `C:\Users\trajano\bin;C:\Program Files\Git\usr\bin:/c/Users/trajano/.local/bin:/c/Users/trajano/AppData/Local/Android/Sdk/platform-tools`
 	got := splitPathEntries(paths)
@@ -56,7 +56,7 @@ func TestSplitPathEntriesWindowsMSYS2MixedDelimiters(t *testing.T) {
 
 func TestGetPathDoesNotMutateEnvironmentPath(t *testing.T) {
 	t.Setenv("MSYSTEM", "")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "pwsh"})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellPwsh})
 
 	original := `C:\Windows\System32;C:\Users\trajano\bin`
 	t.Setenv("PATH", original)
@@ -67,7 +67,7 @@ func TestGetPathDoesNotMutateEnvironmentPath(t *testing.T) {
 
 func TestCleanPathUsesCygpath(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "bash", Cygpath: CygpathExternal})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellBash, Cygpath: CygpathExternal})
 	clearCleanPathCache()
 	t.Cleanup(clearCleanPathCache)
 
@@ -84,7 +84,7 @@ func TestCleanPathUsesCygpath(t *testing.T) {
 
 func TestCleanPathKeepsWindowsPathWhenCygpathFails(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "bash", Cygpath: CygpathExternal})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellBash, Cygpath: CygpathExternal})
 	clearCleanPathCache()
 	t.Cleanup(clearCleanPathCache)
 
@@ -100,7 +100,7 @@ func TestCleanPathKeepsWindowsPathWhenCygpathFails(t *testing.T) {
 
 func TestCleanPathCachesCygpathResult(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "bash", Cygpath: CygpathExternal})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellBash, Cygpath: CygpathExternal})
 	clearCleanPathCache()
 	t.Cleanup(clearCleanPathCache)
 
@@ -121,7 +121,7 @@ func TestCleanPathCachesCygpathResult(t *testing.T) {
 
 func TestCleanPathUsesInternalCygpathByDefault(t *testing.T) {
 	t.Setenv("MSYSTEM", "MINGW64")
-	SetCurrent(&Runtime{OS: WINDOWS, Shell: "bash"})
+	SetCurrent(&Runtime{OS: WINDOWS, Shell: shellBash})
 	clearCleanPathCache()
 	t.Cleanup(clearCleanPathCache)
 

--- a/src/context/runtime.go
+++ b/src/context/runtime.go
@@ -59,7 +59,7 @@ func NewRuntime(shell string) *Runtime {
 
 func isShellLike(shell string) bool {
 	switch strings.ToLower(strings.TrimSpace(shell)) {
-	case "bash", "zsh", "fish", "tcsh", "pwsh", "powershell":
+	case shellBash, shellZsh, shellFish, shellTcsh, shellPwsh, shellPowerShell:
 		return true
 	default:
 		return false

--- a/src/context/runtime_test.go
+++ b/src/context/runtime_test.go
@@ -2,8 +2,6 @@ package context
 
 import "testing"
 
-const testShellBash = "bash"
-
 func TestIsWSL(t *testing.T) {
 	originalGOOS := runtimeGOOS
 	t.Cleanup(func() {
@@ -49,11 +47,12 @@ func TestIsWSL(t *testing.T) {
 
 func TestInitLoadsEnvironmentMap(t *testing.T) {
 	t.Setenv("ALIAE_ENV_TEST", "test-value")
-	Init(testShellBash)
+	Init(shellBash)
 	current := GetCurrent()
 
 	if current == nil {
 		t.Fatalf("expected runtime context to be initialized")
+		return
 	}
 
 	if current.Env["ALIAE_ENV_TEST"] != "test-value" {
@@ -74,13 +73,14 @@ func TestNewRuntimeBuildsRuntimeWithoutMutatingCurrent(t *testing.T) {
 	t.Cleanup(func() { SetCurrent(original) })
 
 	SetCurrent(nil)
-	current := NewRuntime(testShellBash)
+	current := NewRuntime(shellBash)
 
 	if current == nil {
 		t.Fatalf("expected runtime context")
+		return
 	}
-	if current.Shell != testShellBash {
-		t.Fatalf("expected shell to be %s, got %s", testShellBash, current.Shell)
+	if current.Shell != shellBash {
+		t.Fatalf("expected shell to be %s, got %s", shellBash, current.Shell)
 	}
 	if GetCurrent() != nil {
 		t.Fatalf("expected current runtime to remain unchanged")
@@ -93,12 +93,12 @@ func TestIsShellLike(t *testing.T) {
 		shell    string
 		expected bool
 	}{
-		{name: "bash", shell: "bash", expected: true},
-		{name: "zsh", shell: "zsh", expected: true},
-		{name: "fish", shell: "fish", expected: true},
-		{name: "tcsh", shell: "tcsh", expected: true},
-		{name: "pwsh", shell: "pwsh", expected: true},
-		{name: "powershell", shell: "powershell", expected: true},
+		{name: shellBash, shell: shellBash, expected: true},
+		{name: shellZsh, shell: shellZsh, expected: true},
+		{name: shellFish, shell: shellFish, expected: true},
+		{name: shellTcsh, shell: shellTcsh, expected: true},
+		{name: shellPwsh, shell: shellPwsh, expected: true},
+		{name: shellPowerShell, shell: shellPowerShell, expected: true},
 		{name: "nu", shell: "nu", expected: false},
 		{name: "cmd", shell: "cmd", expected: false},
 		{name: "xonsh", shell: "xonsh", expected: false},

--- a/src/context/shell_constants.go
+++ b/src/context/shell_constants.go
@@ -1,0 +1,10 @@
+package context
+
+const (
+	shellBash       = "bash"
+	shellZsh        = "zsh"
+	shellFish       = "fish"
+	shellTcsh       = "tcsh"
+	shellPwsh       = "pwsh"
+	shellPowerShell = "powershell"
+)

--- a/src/shell/aliae_test.go
+++ b/src/shell/aliae_test.go
@@ -16,17 +16,17 @@ func TestAliasCommand(t *testing.T) {
 		Expected string
 	}{
 		{
-			Case:     "PWSH",
+			Case:     PWSH,
 			Shell:    PWSH,
 			Expected: `Set-Alias -Name foo -Value "bar"`,
 		},
 		{
-			Case:     "CMD",
+			Case:     CMD,
 			Shell:    CMD,
 			Expected: "macrofile:write(\"foo=bar\", \"\\n\")",
 		},
 		{
-			Case:     "FISH",
+			Case:     FISH,
 			Shell:    FISH,
 			Expected: `alias foo "bar"`,
 		},
@@ -51,7 +51,7 @@ func TestAliasCommand(t *testing.T) {
 			Expected: `alias foo="bar"`,
 		},
 		{
-			Case:     "BASH",
+			Case:     BASH,
 			Shell:    BASH,
 			Expected: `alias foo="bar"`,
 		},
@@ -180,21 +180,21 @@ func TestAliaeRender(t *testing.T) {
 		{
 			Case: "Single alias",
 			Aliae: Aliae{
-				&Alias{Name: "FOO", Value: "bar"},
+				&Alias{Name: testNameFooUpper, Value: "bar"},
 			},
 			Expected: `alias FOO="bar"`,
 		},
 		{
 			Case: "Invalid type",
 			Aliae: Aliae{
-				&Alias{Name: "FOO", Value: "bar", Type: "invalid"},
+				&Alias{Name: testNameFooUpper, Value: "bar", Type: "invalid"},
 			},
 		},
 		{
 			Case: "Double alias",
 			Aliae: Aliae{
-				&Alias{Name: "FOO", Value: "bar"},
-				&Alias{Name: "BAR", Value: "foo"},
+				&Alias{Name: testNameFooUpper, Value: "bar"},
+				&Alias{Name: testNameBarUpper, Value: "foo"},
 			},
 			Expected: `alias FOO="bar"
 alias BAR="foo"`,
@@ -202,7 +202,7 @@ alias BAR="foo"`,
 		{
 			Case: "Filtered out",
 			Aliae: Aliae{
-				&Alias{Name: "FOO", Value: "bar", If: `eq .Shell "fish"`},
+				&Alias{Name: testNameFooUpper, Value: "bar", If: `eq .Shell "fish"`},
 			},
 		},
 	}
@@ -222,12 +222,12 @@ func TestAliasWithTemplate(t *testing.T) {
 		Expected string
 	}{
 		{
-			Case:     "No template",
+			Case:     testCaseNoTemplate,
 			Value:    "cd ~",
 			Expected: `alias a="cd ~"`,
 		},
 		{
-			Case:     "Home in template",
+			Case:     testCaseHomeInTemplate,
 			Value:    "{{ .Home }}/go/bin/aliae",
 			Expected: `alias a="/Users/jan/go/bin/aliae"`,
 		},
@@ -240,7 +240,7 @@ func TestAliasWithTemplate(t *testing.T) {
 
 	for _, tc := range cases {
 		alias := &Alias{Name: "a", Value: tc.Value}
-		useRuntime(t, &context.Runtime{Shell: BASH, Home: "/Users/jan", OS: context.WINDOWS})
+		useRuntime(t, &context.Runtime{Shell: BASH, Home: testHomeUnix, OS: context.WINDOWS})
 		assert.Equal(t, tc.Expected, alias.string(), tc.Case)
 	}
 }

--- a/src/shell/cdpath_test.go
+++ b/src/shell/cdpath_test.go
@@ -20,37 +20,37 @@ func TestCDPath(t *testing.T) {
 	}{
 		{
 			Case:  "Unknown shell",
-			Shell: "FOO",
+			Shell: testShellUnknown,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 		},
 		{
 			Case:  "PWSH is skipped",
 			Shell: PWSH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 		},
 		{
 			Case:  "CMD is skipped",
 			Shell: CMD,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 		},
 		{
 			Case:  "NU is skipped",
 			Shell: NU,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 		},
 		{
 			Case:  "BASH - single item",
 			Shell: BASH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"`,
 		},
@@ -58,7 +58,7 @@ func TestCDPath(t *testing.T) {
 			Case:  "BASH - multiple items",
 			Shell: BASH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share\n/usr/share",
+				Value: testUsrLocalShare + "\n" + testUsrShare,
 			},
 			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"
 export CDPATH="${CDPATH:+$CDPATH:}/usr/share"`,
@@ -67,7 +67,7 @@ export CDPATH="${CDPATH:+$CDPATH:}/usr/share"`,
 			Case:  "ZSH - single item",
 			Shell: ZSH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 			Expected: `cdpath=( $cdpath /usr/local/share )`,
 		},
@@ -75,7 +75,7 @@ export CDPATH="${CDPATH:+$CDPATH:}/usr/share"`,
 			Case:  "FISH - single item",
 			Shell: FISH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 			Expected: `set -g cdpath $cdpath /usr/local/share`,
 		},
@@ -83,7 +83,7 @@ export CDPATH="${CDPATH:+$CDPATH:}/usr/share"`,
 			Case:  "TCSH - single item",
 			Shell: TCSH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 			Expected: `set cdpath = ( $cdpath /usr/local/share );`,
 		},
@@ -91,7 +91,7 @@ export CDPATH="${CDPATH:+$CDPATH:}/usr/share"`,
 			Case:  "XONSH - single item",
 			Shell: XONSH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 			Expected: `$CDPATH = $CDPATH + ["/usr/local/share"]`,
 		},
@@ -100,7 +100,7 @@ export CDPATH="${CDPATH:+$CDPATH:}/usr/share"`,
 	for _, tc := range cases {
 		useRuntime(t, &context.Runtime{
 			Shell:  tc.Shell,
-			Home:   "/Users/jan",
+			Home:   testHomeUnix,
 			OS:     tc.OS,
 			CDPath: &context.Path{"/opt/cd", "."},
 		})
@@ -119,7 +119,7 @@ func TestCDPathForce(t *testing.T) {
 			Case:  "BASH - Not Force",
 			Shell: BASH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 			},
 			Expected: "",
 		},
@@ -127,7 +127,7 @@ func TestCDPathForce(t *testing.T) {
 			Case:  "BASH - Force",
 			Shell: BASH,
 			CDPath: &CDPath{
-				Value: "/usr/local/share",
+				Value: testUsrLocalShare,
 				Force: true,
 			},
 			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"`,
@@ -137,7 +137,7 @@ func TestCDPathForce(t *testing.T) {
 	for _, tc := range cases {
 		useRuntime(t, &context.Runtime{
 			Shell:  tc.Shell,
-			CDPath: &context.Path{"/usr/local/share", "."},
+			CDPath: &context.Path{testUsrLocalShare, "."},
 		})
 		assert.Equal(t, tc.Expected, tc.CDPath.string(), tc.Case)
 	}
@@ -159,14 +159,14 @@ func TestCDPathRender(t *testing.T) {
 		{
 			Case: "If false",
 			CDPaths: CDPaths{
-				&CDPath{Value: "/usr/share", If: `eq .Shell "fish"`},
+				&CDPath{Value: testUsrShare, If: `eq .Shell "fish"`},
 			},
 			Shell: BASH,
 		},
 		{
 			Case: "If true",
 			CDPaths: CDPaths{
-				&CDPath{Value: "/usr/share", If: `eq .Shell "bash"`},
+				&CDPath{Value: testUsrShare, If: `eq .Shell "bash"`},
 			},
 			Shell: BASH,
 			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/share"
@@ -175,7 +175,7 @@ if [ -n "$CDPATH" ]; then export CDPATH=":$CDPATH"; else export CDPATH=":"; fi`,
 		{
 			Case: "Single definition with non-empty script",
 			CDPaths: CDPaths{
-				&CDPath{Value: "/usr/share"},
+				&CDPath{Value: testUsrShare},
 			},
 			Shell:          BASH,
 			NonEmptyScript: true,
@@ -187,8 +187,8 @@ if [ -n "$CDPATH" ]; then export CDPATH=":$CDPATH"; else export CDPATH=":"; fi`,
 		{
 			Case: "Two definitions",
 			CDPaths: CDPaths{
-				&CDPath{Value: "/usr/share"},
-				&CDPath{Value: "/usr/local/share"},
+				&CDPath{Value: testUsrShare},
+				&CDPath{Value: testUsrLocalShare},
 			},
 			Shell: BASH,
 			Expected: `export CDPATH="${CDPATH:+$CDPATH:}/usr/share"
@@ -240,7 +240,7 @@ func TestCDPathEnsuresCurrentDir(t *testing.T) {
 		Shell:  BASH,
 		CDPath: &context.Path{},
 	})
-	paths := CDPaths{&CDPath{Value: "/usr/local/share"}}
+	paths := CDPaths{&CDPath{Value: testUsrLocalShare}}
 	paths.Render()
 	expected := `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"` + "\n" +
 		`if [ -n "$CDPATH" ]; then export CDPATH=":$CDPATH"; else export CDPATH=":"; fi`
@@ -254,7 +254,7 @@ func TestCDPathDoesNotInjectCurrentDirWhenAlreadyPresent(t *testing.T) {
 		CDPath: &context.Path{".", "/existing"},
 	})
 
-	paths := CDPaths{&CDPath{Value: "/usr/local/share"}}
+	paths := CDPaths{&CDPath{Value: testUsrLocalShare}}
 	paths.Render()
 	assert.Equal(t, `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"`, strings.TrimSpace(RenderOutputString()))
 }
@@ -264,6 +264,6 @@ func TestCDPathWithExistingCurrentDirSkipsDotInsertion(t *testing.T) {
 		Shell:  BASH,
 		CDPath: &context.Path{".", "/existing"},
 	})
-	cdpath := &CDPath{Value: "/usr/local/share"}
+	cdpath := &CDPath{Value: testUsrLocalShare}
 	assert.Equal(t, `export CDPATH="${CDPATH:+$CDPATH:}/usr/local/share"`, cdpath.string())
 }

--- a/src/shell/echo_test.go
+++ b/src/shell/echo_test.go
@@ -15,7 +15,7 @@ func TestEcho(t *testing.T) {
 		Error    bool
 	}{
 		{
-			Case:  "PWSH",
+			Case:  PWSH,
 			Shell: PWSH,
 			Expected: `$message = @"
 hello
@@ -23,7 +23,7 @@ hello
 Write-Host $message`,
 		},
 		{
-			Case:  "CMD",
+			Case:  CMD,
 			Shell: CMD,
 			Expected: `message = [[
 hello
@@ -31,7 +31,7 @@ hello
 print(message)`,
 		},
 		{
-			Case:     "FISH",
+			Case:     FISH,
 			Shell:    FISH,
 			Expected: `echo "hello"`,
 		},
@@ -57,7 +57,7 @@ print(message)`,
 			Expected: `echo "hello"`,
 		},
 		{
-			Case:     "BASH",
+			Case:     BASH,
 			Shell:    BASH,
 			Expected: `echo "hello"`,
 		},

--- a/src/shell/env_test.go
+++ b/src/shell/env_test.go
@@ -11,7 +11,7 @@ import (
 
 func TestEnvironmentVariable(t *testing.T) {
 	envs := map[EnvType]Env{
-		String: {Name: "HELLO", Value: "world"},
+		String: {Name: testHelloEnvName, Value: "world"},
 		Array:  {Name: "ARRAY", Value: "hello array world", Type: "array"},
 	}
 	cases := []struct {
@@ -21,7 +21,7 @@ func TestEnvironmentVariable(t *testing.T) {
 		Env      Env
 	}{
 		{
-			Case:     "PWSH",
+			Case:     PWSH,
 			Shell:    PWSH,
 			Env:      envs[String],
 			Expected: `$env:HELLO = "world"`,
@@ -33,13 +33,13 @@ func TestEnvironmentVariable(t *testing.T) {
 			Expected: `$env:ARRAY = @("hello","array","world")`,
 		},
 		{
-			Case:     "CMD",
+			Case:     CMD,
 			Shell:    CMD,
 			Env:      envs[String],
 			Expected: `os.setenv("HELLO", "world")`,
 		},
 		{
-			Case:     "FISH",
+			Case:     FISH,
 			Shell:    FISH,
 			Env:      envs[String],
 			Expected: "set --global --export HELLO world",
@@ -93,7 +93,7 @@ func TestEnvironmentVariable(t *testing.T) {
 			Expected: `export ARRAY=("hello" "array" "world")`,
 		},
 		{
-			Case:     "BASH",
+			Case:     BASH,
 			Shell:    BASH,
 			Env:      envs[String],
 			Expected: `export HELLO="world"`,
@@ -124,12 +124,12 @@ func TestEnvironmentVariableWithTemplate(t *testing.T) {
 		Expected string
 	}{
 		{
-			Case:     "No template",
+			Case:     testCaseNoTemplate,
 			Value:    "~",
 			Expected: `export HELLO="~"`,
 		},
 		{
-			Case:     "Home in template",
+			Case:     testCaseHomeInTemplate,
 			Value:    "{{ .Home }}/.posh.omp.json",
 			Expected: `export HELLO="/Users/jan/.posh.omp.json"`,
 		},
@@ -141,19 +141,19 @@ func TestEnvironmentVariableWithTemplate(t *testing.T) {
 	}
 
 	for _, tc := range cases {
-		env := &Env{Name: "HELLO", Value: tc.Value}
-		useRuntime(t, &context.Runtime{Shell: BASH, Home: "/Users/jan"})
+		env := &Env{Name: testHelloEnvName, Value: tc.Value}
+		useRuntime(t, &context.Runtime{Shell: BASH, Home: testHomeUnix})
 		assert.Equal(t, tc.Expected, env.string(), tc.Case)
 	}
 }
 
 func TestEnvFilter(t *testing.T) {
 	env := Envs{
-		&Env{Name: "FOO", Value: "bar"},
-		&Env{Name: "BAR", Value: "foo"},
+		&Env{Name: testNameFooUpper, Value: "bar"},
+		&Env{Name: testNameBarUpper, Value: "foo"},
 		&Env{Name: "BAZ", Value: "baz", If: `eq .Shell "zsh"`},
 	}
-	useRuntime(t, &context.Runtime{Shell: "FISH"})
+	useRuntime(t, &context.Runtime{Shell: FISH})
 	filtered := env.filter()
 	assert.Len(t, filtered, 2)
 }
@@ -284,7 +284,7 @@ func TestEnvironmentVariablePathNormalizationOnWindows(t *testing.T) {
 
 	for _, tc := range cases {
 		env := &Env{Name: "ANDROID_SDK_ROOT", Value: tc.Value, IsPath: true}
-		useRuntime(t, &context.Runtime{Shell: PWSH, OS: context.WINDOWS, Home: `C:\Users\trajano`})
+		useRuntime(t, &context.Runtime{Shell: PWSH, OS: context.WINDOWS, Home: testHomeWindows})
 		assert.Equal(t, tc.Expected, env.string(), tc.Case)
 	}
 }
@@ -321,7 +321,7 @@ func TestEnvironmentVariableIfExists(t *testing.T) {
 	_ = os.Unsetenv("ALIAE_MISSING")
 
 	ResetRenderOutput()
-	useRuntime(t, &context.Runtime{Shell: PWSH, OS: context.LINUX, Home: "/home/trajano"})
+	useRuntime(t, &context.Runtime{Shell: PWSH, OS: context.LINUX, Home: testHomeLinux})
 	envs := Envs{
 		&Env{Name: "ALIAE_EXISTING", Value: existing, IsPath: true, IfExists: true},
 		&Env{Name: "ALIAE_MISSING", Value: missing, IsPath: true, IfExists: true},
@@ -363,13 +363,13 @@ func TestEnvironmentVariableIsPathMultilineUsesFirstExisting(t *testing.T) {
 	firstMissing := filepath.Join(t.TempDir(), "missing-first")
 	secondExisting := t.TempDir()
 	thirdExisting := t.TempDir()
-	_ = os.Unsetenv("ANDROID_HOME")
+	_ = os.Unsetenv(testAndroidHome)
 
 	ResetRenderOutput()
 	useRuntime(t, &context.Runtime{Shell: PWSH, OS: context.LINUX, Home: "/home/trajano"})
 	envs := Envs{
 		&Env{
-			Name: "ANDROID_HOME",
+			Name: testAndroidHome,
 			Value: firstMissing + "\n" +
 				secondExisting + "\n" +
 				thirdExisting,
@@ -382,39 +382,39 @@ func TestEnvironmentVariableIsPathMultilineUsesFirstExisting(t *testing.T) {
 	assert.Contains(t, RenderOutputString(), secondExisting)
 	assert.NotContains(t, RenderOutputString(), firstMissing)
 	assert.NotContains(t, RenderOutputString(), thirdExisting)
-	assert.Equal(t, secondExisting, os.Getenv("ANDROID_HOME"))
+	assert.Equal(t, secondExisting, os.Getenv(testAndroidHome))
 }
 
 func TestEnvironmentVariableIsPathMultilineSkipsWhenNoneExists(t *testing.T) {
 	firstMissing := filepath.Join(t.TempDir(), "missing-first")
 	secondMissing := filepath.Join(t.TempDir(), "missing-second")
 
-	_ = os.Unsetenv("ANDROID_HOME")
+	_ = os.Unsetenv(testAndroidHome)
 
 	ResetRenderOutput()
 	useRuntime(t, &context.Runtime{Shell: PWSH, OS: context.LINUX, Home: "/home/trajano"})
 	envs := Envs{
 		&Env{
-			Name:   "ANDROID_HOME",
+			Name:   testAndroidHome,
 			Value:  firstMissing + "\n" + secondMissing,
 			IsPath: true,
 		},
 	}
 	envs.Render()
 
-	assert.NotContains(t, RenderOutputString(), "ANDROID_HOME")
-	assert.Equal(t, "", os.Getenv("ANDROID_HOME"))
+	assert.NotContains(t, RenderOutputString(), testAndroidHome)
+	assert.Equal(t, "", os.Getenv(testAndroidHome))
 }
 
 func TestEnvironmentVariableIsPathSingleLineStillExportsByDefault(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "missing")
-	_ = os.Unsetenv("ANDROID_HOME")
+	_ = os.Unsetenv(testAndroidHome)
 
 	ResetRenderOutput()
 	useRuntime(t, &context.Runtime{Shell: PWSH, OS: context.LINUX, Home: "/home/trajano"})
 	envs := Envs{
 		&Env{
-			Name:   "ANDROID_HOME",
+			Name:   testAndroidHome,
 			Value:  missing,
 			IsPath: true,
 		},
@@ -423,5 +423,5 @@ func TestEnvironmentVariableIsPathSingleLineStillExportsByDefault(t *testing.T) 
 
 	assert.Contains(t, RenderOutputString(), `$env:ANDROID_HOME = "`)
 	assert.Contains(t, RenderOutputString(), missing)
-	assert.Equal(t, missing, os.Getenv("ANDROID_HOME"))
+	assert.Equal(t, missing, os.Getenv(testAndroidHome))
 }

--- a/src/shell/filesystem.go
+++ b/src/shell/filesystem.go
@@ -1,0 +1,77 @@
+package shell
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+func filesEqual(name string, data []byte) bool {
+	existing, err := os.ReadFile(name)
+	return err == nil && bytes.Equal(existing, data)
+}
+
+func writeFileAtomic(path string, data []byte, perm os.FileMode) error {
+	if filesEqual(path, data) {
+		return nil
+	}
+
+	// the temp file must be in the same directory as the target,
+	// os.Rename is only atomic within the same volume
+	tmp, err := os.CreateTemp(filepath.Dir(path), filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+
+	defer os.Remove(tmp.Name())
+
+	if _, err = tmp.Write(data); err != nil {
+		tmp.Close()
+		return err
+	}
+
+	// CreateTemp creates the file with 0600
+	if err = tmp.Chmod(perm); err != nil {
+		tmp.Close()
+		return err
+	}
+
+	if err = tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmp.Name(), path)
+}
+
+// writeFile writes data to path, atomically when possible.
+//
+// On Windows, replacing a file via rename requires that no process has the
+// target open: MoveFileEx(MOVEFILE_REPLACE_EXISTING) fails with
+// ERROR_ACCESS_DENIED as long as a single handle exists, even one opened
+// with full sharing. Shells load the init script on startup, so brief holds
+// are normal — retry those. When the file is still held after the retries
+// (a shell keeping it open), fall back to an in-place write: sharing rules
+// allow overwriting a file others are reading, we only lose atomicity for
+// this write.
+func writeFile(path string, data []byte, perm os.FileMode) error {
+	const attempts = 4
+	wait := 50 * time.Millisecond
+
+	var err error
+
+	for attempt := 1; ; attempt++ {
+		if err = writeFileAtomic(path, data, perm); !canRetryWrite(err) || attempt == attempts {
+			break
+		}
+
+		time.Sleep(wait)
+		wait *= 2
+	}
+
+	if err == nil || !canRetryWrite(err) {
+		return err
+	}
+
+	return os.WriteFile(path, data, perm)
+}

--- a/src/shell/filesystem_other.go
+++ b/src/shell/filesystem_other.go
@@ -1,0 +1,9 @@
+//go:build !windows
+
+package shell
+
+// only Windows knows transient file-sharing violations worth retrying,
+// on other platforms a write error is always persistent
+func canRetryWrite(_ error) bool {
+	return false
+}

--- a/src/shell/filesystem_test.go
+++ b/src/shell/filesystem_test.go
@@ -1,0 +1,53 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWriteFile(t *testing.T) {
+	cases := []struct {
+		Case     string
+		Existing string
+		Data     string
+	}{
+		{
+			Case: "new file",
+			Data: "alias foo = bar",
+		},
+		{
+			Case:     "unchanged content",
+			Existing: "alias foo = bar",
+			Data:     "alias foo = bar",
+		},
+		{
+			Case:     "changed content",
+			Existing: "alias foo = bar",
+			Data:     "alias foo = baz",
+		},
+	}
+
+	for _, tc := range cases {
+		path := filepath.Join(t.TempDir(), "aliae.nu")
+
+		if len(tc.Existing) != 0 {
+			require.NoError(t, os.WriteFile(path, []byte(tc.Existing), 0o644), tc.Case)
+		}
+
+		err := writeFile(path, []byte(tc.Data), 0o644)
+		require.NoError(t, err, tc.Case)
+
+		got, err := os.ReadFile(path)
+		require.NoError(t, err, tc.Case)
+		assert.Equal(t, tc.Data, string(got), tc.Case)
+
+		// no temp files left behind
+		entries, err := os.ReadDir(filepath.Dir(path))
+		require.NoError(t, err, tc.Case)
+		assert.Len(t, entries, 1, tc.Case)
+	}
+}

--- a/src/shell/filesystem_windows.go
+++ b/src/shell/filesystem_windows.go
@@ -1,0 +1,28 @@
+package shell
+
+import (
+	"errors"
+	"syscall"
+
+	"golang.org/x/sys/windows"
+)
+
+// canRetryWrite reports whether the write failed because another process
+// holds the file (or its rename target) open, making a retry or an in-place
+// write worthwhile. Replacing an open file via rename fails with
+// ERROR_ACCESS_DENIED, not a sharing violation: MoveFileEx with
+// MOVEFILE_REPLACE_EXISTING requires the target to have no open handles at
+// all. All other errors are considered persistent.
+func canRetryWrite(err error) bool {
+	var errno syscall.Errno
+	if !errors.As(err, &errno) {
+		return false
+	}
+
+	switch errno {
+	case windows.ERROR_ACCESS_DENIED, windows.ERROR_SHARING_VIOLATION, windows.ERROR_LOCK_VIOLATION:
+		return true
+	default:
+		return false
+	}
+}

--- a/src/shell/filesystem_windows.go
+++ b/src/shell/filesystem_windows.go
@@ -19,6 +19,7 @@ func canRetryWrite(err error) bool {
 		return false
 	}
 
+	//nolint:exhaustive // only transient sharing errors are retried
 	switch errno {
 	case windows.ERROR_ACCESS_DENIED, windows.ERROR_SHARING_VIOLATION, windows.ERROR_LOCK_VIOLATION:
 		return true

--- a/src/shell/git_test.go
+++ b/src/shell/git_test.go
@@ -15,11 +15,11 @@ func TestGit(t *testing.T) {
 	}{
 		{
 			Case:  "Known value",
-			Alias: &Alias{Name: "hello", Value: "!echo world"},
+			Alias: &Alias{Name: "hello", Value: testGitBangEchoWorld},
 		},
 		{
 			Case:  "Error",
-			Alias: &Alias{Name: "hello", Value: "!echo world"},
+			Alias: &Alias{Name: "hello", Value: testGitBangEchoWorld},
 			Error: true,
 		},
 		{
@@ -31,7 +31,7 @@ func TestGit(t *testing.T) {
 
 	for _, tc := range cases {
 		gitConfigCache = map[string]string{
-			"hello": "!echo world",
+			"hello": testGitBangEchoWorld,
 		}
 		gitError = tc.Error
 		assert.Equal(t, tc.Expected, tc.Alias.git(), tc.Case)

--- a/src/shell/if.go
+++ b/src/shell/if.go
@@ -8,6 +8,8 @@ import (
 
 type If string
 
+const booleanTrue = "true"
+
 func (i If) Ignore() bool {
 	if len(i) == 0 {
 		return false
@@ -18,7 +20,7 @@ func (i If) Ignore() bool {
 		return false
 	}
 
-	return got == "true"
+	return got == booleanTrue
 }
 
 func (i If) Validate() error {

--- a/src/shell/link_test.go
+++ b/src/shell/link_test.go
@@ -17,17 +17,17 @@ func TestLinkCommand(t *testing.T) {
 		OS       string
 	}{
 		{
-			Case:     "PWSH",
+			Case:     PWSH,
 			Shell:    PWSH,
 			Expected: "New-Item -Path \"foo\" -ItemType SymbolicLink -Value \"bar\" -Force | Out-Null",
 		},
 		{
-			Case:     "CMD",
+			Case:     CMD,
 			Shell:    CMD,
 			Expected: `os.execute("mklink /h foo bar > nul 2>&1")`,
 		},
 		{
-			Case:     "FISH",
+			Case:     FISH,
 			Shell:    FISH,
 			Expected: "ln -sf bar foo",
 		},
@@ -58,7 +58,7 @@ func TestLinkCommand(t *testing.T) {
 			Expected: `ln -sf bar foo`,
 		},
 		{
-			Case:     "BASH",
+			Case:     BASH,
 			Shell:    BASH,
 			Expected: `ln -sf bar foo`,
 		},
@@ -80,15 +80,15 @@ func TestLinkRender(t *testing.T) {
 		{
 			Case: "Single link",
 			Links: Links{
-				&Link{Name: "FOO", Target: "bar", force: true},
+				&Link{Name: testNameFooUpper, Target: "bar", force: true},
 			},
 			Expected: "ln -sf bar FOO",
 		},
 		{
 			Case: "Double link",
 			Links: Links{
-				&Link{Name: "FOO", Target: "bar", force: true},
-				&Link{Name: "BAR", Target: "foo", force: true},
+				&Link{Name: testNameFooUpper, Target: "bar", force: true},
+				&Link{Name: testNameBarUpper, Target: "foo", force: true},
 			},
 			Expected: `ln -sf bar FOO
 ln -sf foo BAR`,
@@ -96,7 +96,7 @@ ln -sf foo BAR`,
 		{
 			Case: "Filtered out",
 			Links: Links{
-				&Link{Name: "FOO", Target: "bar", If: `eq .Shell "fish"`, force: true},
+				&Link{Name: testNameFooUpper, Target: "bar", If: `eq .Shell "fish"`, force: true},
 			},
 		},
 	}
@@ -116,12 +116,12 @@ func TestLinkWithTemplate(t *testing.T) {
 		Expected string
 	}{
 		{
-			Case:     "No template",
+			Case:     testCaseNoTemplate,
 			Target:   "~/dotfiles/zshrc",
 			Expected: `ln -sf ~/dotfiles/zshrc /tmp/l`,
 		},
 		{
-			Case:     "Home in template",
+			Case:     testCaseHomeInTemplate,
 			Target:   "{{ .Home }}/.aliae.yaml",
 			Expected: `ln -sf /Users/jan/.aliae.yaml /tmp/l`,
 		},
@@ -134,7 +134,7 @@ func TestLinkWithTemplate(t *testing.T) {
 
 	for _, tc := range cases {
 		link := &Link{Name: "/tmp/l", Target: tc.Target, force: true}
-		useRuntime(t, &context.Runtime{Shell: BASH, Home: "/Users/jan", OS: context.WINDOWS})
+		useRuntime(t, &context.Runtime{Shell: BASH, Home: testHomeUnix, OS: context.WINDOWS})
 		assert.Equal(t, tc.Expected, link.string(), tc.Case)
 	}
 }

--- a/src/shell/nu.go
+++ b/src/shell/nu.go
@@ -1,9 +1,13 @@
 package shell
 
 import (
+	context_ "context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 
 	"github.com/jandedobbeleer/aliae/src/context"
 )
@@ -12,6 +16,12 @@ const (
 	NU              = "nu"
 	NuEnvBlockStart = "export-env {\n"
 	NuEnvBlockEnd   = "\n}"
+
+	nuScriptName = "aliae.nu"
+
+	// nuGuard makes the autoload script a no-op once aliae is uninstalled,
+	// as removing the `aliae init nu` line doesn't remove the script.
+	nuGuard = "if (which aliae | is-empty) { return }\n\n"
 )
 
 type nuFormatStrategy struct{}
@@ -85,18 +95,94 @@ func (nuFormatStrategy) FormatEcho(e *Echo) string {
 
 func (nuFormatStrategy) FormatCDPathCurrentDirScript() string { return "" }
 
+// NuInit writes the init script to Nushell's vendor autoload directory.
+// Nushell (v0.104.0+) loads autoload scripts after config.nu, so the script
+// written by a single `aliae init nu` line in config.nu is picked up in the
+// same session.
 func NuInit(script string) error {
-	initPath := filepath.Join(context.Home(), ".aliae.nu")
+	removeLegacyNuScript()
 
-	f, err := os.OpenFile(initPath, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+	dir, err := nuAutoloadDir()
 	if err != nil {
 		return err
 	}
 
-	_, err = f.WriteString(script)
-	if err != nil {
-		return err
+	return writeFile(filepath.Join(dir, nuScriptName), []byte(nuGuard+script), 0o644)
+}
+
+// nuAutoloadDir resolves Nushell's vendor autoload directory. The result is
+// cached on disk to avoid spawning nu on every shell startup.
+func nuAutoloadDir() (string, error) {
+	cachePath := nuAutoloadDirCachePath()
+
+	if dir := cachedNuAutoloadDir(cachePath); len(dir) != 0 {
+		return dir, nil
 	}
 
-	return f.Close()
+	out, err := exec.CommandContext(context_.Background(), "nu", "-c", "$nu.data-dir | path join vendor autoload").Output()
+	if err != nil {
+		return "", fmt.Errorf("unable to resolve the Nushell autoload directory: %w", err)
+	}
+
+	dir := strings.TrimSpace(string(out))
+	if len(dir) == 0 {
+		return "", errors.New("unable to resolve the Nushell autoload directory")
+	}
+
+	if err = os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+
+	cacheNuAutoloadDir(cachePath, dir)
+
+	return dir, nil
+}
+
+func nuAutoloadDirCachePath() string {
+	dir, err := os.UserCacheDir()
+	if err != nil {
+		return ""
+	}
+
+	return filepath.Join(dir, "aliae", "nu-autoload-dir")
+}
+
+func cachedNuAutoloadDir(cachePath string) string {
+	if len(cachePath) == 0 {
+		return ""
+	}
+
+	data, err := os.ReadFile(cachePath)
+	if err != nil {
+		return ""
+	}
+
+	dir := strings.TrimSpace(string(data))
+	if len(dir) == 0 {
+		return ""
+	}
+
+	// the autoload directory might have been removed since it was cached
+	if _, err = os.Stat(dir); err != nil {
+		return ""
+	}
+
+	return dir
+}
+
+func cacheNuAutoloadDir(cachePath, dir string) {
+	if len(cachePath) == 0 {
+		return
+	}
+
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0o700); err != nil {
+		return
+	}
+
+	_ = os.WriteFile(cachePath, []byte(dir), 0o644)
+}
+
+// removeLegacyNuScript deletes the pre-autoload init script at ~/.aliae.nu.
+func removeLegacyNuScript() {
+	_ = os.Remove(filepath.Join(context.Home(), ".aliae.nu"))
 }

--- a/src/shell/path_test.go
+++ b/src/shell/path_test.go
@@ -20,13 +20,13 @@ func TestPath(t *testing.T) {
 	}{
 		{
 			Case:  "Unknown shell",
-			Shell: "FOO",
-			Path:  &Path{Value: "/usr/local/bin"},
+			Shell: testShellUnknown,
+			Path:  &Path{Value: testUsrLocalBin},
 		},
 		{
 			Case:     "PWSH - single item",
 			Shell:    PWSH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH`,
 		},
 		{
@@ -34,14 +34,14 @@ func TestPath(t *testing.T) {
 			Shell:    PWSH,
 			OS:       context.WINDOWS,
 			Path:     &Path{Value: "C:/Users/jan/.tools/bin"},
-			Expected: `$env:PATH = "C:\Users\jan\.tools\bin" + ';' + $env:PATH`,
+			Expected: testPathPwshWindows,
 		},
 		{
 			Case:     "PWSH - Windows converts MSYS paths",
 			Shell:    PWSH,
 			OS:       context.WINDOWS,
 			Path:     &Path{Value: "/c/Users/jan/.tools/bin"},
-			Expected: `$env:PATH = "C:\Users\jan\.tools\bin" + ';' + $env:PATH`,
+			Expected: testPathPwshWindows,
 		},
 		{
 			Case:     "PWSH - single item with template",
@@ -52,47 +52,47 @@ func TestPath(t *testing.T) {
 		{
 			Case:  "PWSH - single item with blank line",
 			Shell: PWSH,
-			Path:  &Path{Value: "/usr/local/bin\n\n/usr/bin"},
+			Path:  &Path{Value: testUsrLocalBin + "\n\n" + testUsrBin},
 			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH
 $env:PATH = "/usr/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case:  "PWSH - multiple items",
 			Shell: PWSH,
-			Path:  &Path{Value: "/usr/local/bin\n/usr/bin"},
+			Path:  &Path{Value: testUsrLocalBinAndUsrBin},
 			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH
 $env:PATH = "/usr/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case:     "CMD - single item",
 			Shell:    CMD,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `os.setenv("PATH", "/usr/local/bin;" .. os.getenv("PATH"))`,
 		},
 		{
 			Case:  "CMD - multiple items",
 			Shell: CMD,
-			Path:  &Path{Value: "/usr/local/bin\n/usr/bin"},
+			Path:  &Path{Value: testUsrLocalBinAndUsrBin},
 			Expected: `os.setenv("PATH", "/usr/local/bin;" .. os.getenv("PATH"))
 os.setenv("PATH", "/usr/bin;" .. os.getenv("PATH"))`,
 		},
 		{
 			Case:     "FISH - single item",
 			Shell:    FISH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `fish_add_path /usr/local/bin`,
 		},
 		{
 			Case:  "FISH - multiple items",
 			Shell: FISH,
-			Path:  &Path{Value: "/usr/local/bin\n/usr/bin"},
+			Path:  &Path{Value: testUsrLocalBinAndUsrBin},
 			Expected: `fish_add_path /usr/local/bin
 fish_add_path /usr/bin`,
 		},
 		{
 			Case:     "NU - single item",
 			Shell:    NU,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `$env.PATH = ($env.PATH | prepend "/usr/local/bin")`,
 		},
 		{
@@ -104,7 +104,7 @@ fish_add_path /usr/bin`,
 		{
 			Case:  "NU - multiple items",
 			Shell: NU,
-			Path:  &Path{Value: "/usr/local/bin\n/usr/bin"},
+			Path:  &Path{Value: testUsrLocalBinAndUsrBin},
 			Expected: `$env.PATH = ($env.PATH | prepend "/usr/local/bin")
 $env.PATH = ($env.PATH | prepend "/usr/bin")`,
 		},
@@ -112,46 +112,46 @@ $env.PATH = ($env.PATH | prepend "/usr/bin")`,
 			Case:  "NU - Windows",
 			Shell: NU,
 			OS:    context.WINDOWS,
-			Path:  &Path{Value: "C:\\bin\nD:\\bin"},
+			Path:  &Path{Value: testWindowsBins},
 			Expected: `$env.Path = ($env.Path | prepend "C:\\bin")
 $env.Path = ($env.Path | prepend "D:\\bin")`,
 		},
 		{
 			Case:     "TCSH - single item",
 			Shell:    TCSH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `set path = ( /usr/local/bin $path );`,
 		},
 		{
 			Case:  "TCSH - multiple items",
 			Shell: TCSH,
-			Path:  &Path{Value: "/usr/local/bin\n/usr/bin"},
+			Path:  &Path{Value: testUsrLocalBinAndUsrBin},
 			Expected: `set path = ( /usr/local/bin $path );
 set path = ( /usr/bin $path );`,
 		},
 		{
 			Case:     "XONSH - single item",
 			Shell:    XONSH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `$PATH.add('/usr/local/bin', True, False)`,
 		},
 		{
 			Case:  "XONSH - multiple items",
 			Shell: XONSH,
-			Path:  &Path{Value: "/usr/local/bin\n/usr/bin"},
+			Path:  &Path{Value: testUsrLocalBinAndUsrBin},
 			Expected: `$PATH.add('/usr/local/bin', True, False)
 $PATH.add('/usr/bin', True, False)`,
 		},
 		{
 			Case:     "ZSH - single item",
 			Shell:    ZSH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `export PATH="/usr/local/bin:$PATH"`,
 		},
 		{
 			Case:  "ZSH - multiple items",
 			Shell: ZSH,
-			Path:  &Path{Value: "/usr/local/bin\n/usr/bin"},
+			Path:  &Path{Value: testUsrLocalBinAndUsrBin},
 			Expected: `export PATH="/usr/local/bin:$PATH"
 export PATH="/usr/bin:$PATH"`,
 		},
@@ -159,14 +159,14 @@ export PATH="/usr/bin:$PATH"`,
 			Case:     "ZSH - Windows",
 			Shell:    ZSH,
 			OS:       context.WINDOWS,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `export PATH="/usr/local/bin;$PATH"`,
 		},
 		{
 			Case:     "BASH - Windows",
 			Shell:    BASH,
 			OS:       context.WINDOWS,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: `export PATH="/usr/local/bin:$PATH"`,
 		},
 		{
@@ -179,7 +179,7 @@ export PATH="/usr/bin:$PATH"`,
 	}
 
 	for _, tc := range cases {
-		useRuntime(t, &context.Runtime{Shell: tc.Shell, Home: "/Users/jan", OS: tc.OS, Path: &context.Path{"/usr/local/bin/src"}})
+		useRuntime(t, &context.Runtime{Shell: tc.Shell, Home: testHomeUnix, OS: tc.OS, Path: &context.Path{testUsrLocalBin + "/src"}})
 		assert.Equal(t, tc.Expected, tc.Path.string(), tc.Case)
 	}
 }
@@ -201,14 +201,14 @@ func TestPathRender(t *testing.T) {
 		{
 			Case: "PWSH - If false",
 			Paths: Paths{
-				&Path{Value: "/usr/bin", If: `eq .Shell "fish"`},
+				&Path{Value: testUsrBin, If: `eq .Shell "fish"`},
 			},
 			Shell: PWSH,
 		},
 		{
 			Case: "PWSH - If true",
 			Paths: Paths{
-				&Path{Value: "/usr/bin", If: `eq .Shell "pwsh"`},
+				&Path{Value: testUsrBin, If: `eq .Shell "pwsh"`},
 			},
 			Shell:    PWSH,
 			Expected: `$env:PATH = "/usr/bin" + ':' + $env:PATH`,
@@ -225,7 +225,7 @@ func TestPathRender(t *testing.T) {
 		{
 			Case: "PWSH - 1 PATH definition",
 			Paths: Paths{
-				&Path{Value: "/usr/bin"},
+				&Path{Value: testUsrBin},
 			},
 			Shell:    PWSH,
 			Expected: `$env:PATH = "/usr/bin" + ':' + $env:PATH`,
@@ -233,7 +233,7 @@ func TestPathRender(t *testing.T) {
 		{
 			Case: "PWSH - Single PATH, non empty",
 			Paths: Paths{
-				&Path{Value: "/usr/bin"},
+				&Path{Value: testUsrBin},
 			},
 			Shell:          PWSH,
 			NonEmptyScript: true,
@@ -244,8 +244,8 @@ $env:PATH = "/usr/bin" + ':' + $env:PATH`,
 		{
 			Case: "PWSH - 2 PATH definitions",
 			Paths: Paths{
-				&Path{Value: "/usr/bin"},
-				&Path{Value: "/Users/jan/.tools/bin"},
+				&Path{Value: testUsrBin},
+				&Path{Value: testHomeUnix + "/.tools/bin"},
 			},
 			Shell: PWSH,
 			Expected: `$env:PATH = "/usr/bin" + ':' + $env:PATH
@@ -254,8 +254,8 @@ $env:PATH = "/Users/jan/.tools/bin" + ':' + $env:PATH`,
 		{
 			Case: "PWSH - 2 PATH definitions with conditional",
 			Paths: Paths{
-				&Path{Value: "/usr/bin", If: `eq .Shell "fish"`},
-				&Path{Value: "/Users/jan/.tools/bin"},
+				&Path{Value: testUsrBin, If: `eq .Shell "fish"`},
+				&Path{Value: testHomeUnix + "/.tools/bin"},
 			},
 			Shell:    PWSH,
 			Expected: `$env:PATH = "/Users/jan/.tools/bin" + ':' + $env:PATH`,
@@ -283,62 +283,62 @@ func TestPathForce(t *testing.T) {
 	}{
 		{
 			Case:  "Unknown shell",
-			Shell: "FOO",
-			Path:  &Path{Value: "/usr/local/bin"},
+			Shell: testShellUnknown,
+			Path:  &Path{Value: testUsrLocalBin},
 		},
 		{
 			Case:     "PWSH - Force",
 			Shell:    PWSH,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `$env:PATH = "/usr/local/bin" + ':' + $env:PATH`,
 		},
 		{
 			Case:     "PWSH - Not Force",
 			Shell:    PWSH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: ``,
 		},
 		{
 			Case:     "CMD - Force",
 			Shell:    CMD,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `os.setenv("PATH", "/usr/local/bin;" .. os.getenv("PATH"))`,
 		},
 		{
 			Case:     "CMD - Not Force",
 			Shell:    CMD,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: ``,
 		},
 		{
 			Case:     "FISH - Force",
 			Shell:    FISH,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `fish_add_path /usr/local/bin`,
 		},
 		{
 			Case:     "FISH - Not Force",
 			Shell:    FISH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: ``,
 		},
 		{
 			Case:     "NU - Force",
 			Shell:    NU,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `$env.PATH = ($env.PATH | prepend "/usr/local/bin")`,
 		},
 		{
 			Case:     "NU - Not Force",
 			Shell:    NU,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: ``,
 		},
 		{
 			Case:  "NU - Windows Force",
 			Shell: NU,
 			OS:    context.WINDOWS,
-			Path:  &Path{Value: "C:\\bin\nD:\\bin", Force: true},
+			Path:  &Path{Value: testWindowsBins, Force: true},
 			Expected: `$env.Path = ($env.Path | prepend "C:\\bin")
 $env.Path = ($env.Path | prepend "D:\\bin")`,
 		},
@@ -346,70 +346,70 @@ $env.Path = ($env.Path | prepend "D:\\bin")`,
 			Case:     "NU - Windows Not Force",
 			Shell:    NU,
 			OS:       context.WINDOWS,
-			Path:     &Path{Value: "C:\\bin\nD:\\bin"},
+			Path:     &Path{Value: testWindowsBins},
 			Expected: ``,
 		},
 		{
 			Case:     "TCSH - Force",
 			Shell:    TCSH,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `set path = ( /usr/local/bin $path );`,
 		},
 		{
 			Case:     "TCSH - Not Force",
 			Shell:    TCSH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: ``,
 		},
 		{
 			Case:     "XONSH - Force",
 			Shell:    XONSH,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `$PATH.add('/usr/local/bin', True, False)`,
 		},
 		{
 			Case:     "XONSH - Not Force",
 			Shell:    XONSH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: ``,
 		},
 		{
 			Case:     "ZSH - Force",
 			Shell:    ZSH,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `export PATH="/usr/local/bin:$PATH"`,
 		},
 		{
 			Case:     "ZSH - Not Force",
 			Shell:    ZSH,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: ``,
 		},
 		{
 			Case:     "ZSH - Windows Force",
 			Shell:    ZSH,
 			OS:       context.WINDOWS,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `export PATH="/usr/local/bin;$PATH"`,
 		},
 		{
 			Case:     "BASH - Windows Force",
 			Shell:    BASH,
 			OS:       context.WINDOWS,
-			Path:     &Path{Value: "/usr/local/bin", Force: true},
+			Path:     &Path{Value: testUsrLocalBin, Force: true},
 			Expected: `export PATH="/usr/local/bin:$PATH"`,
 		},
 		{
 			Case:     "ZSH - Windows Not Force",
 			Shell:    ZSH,
 			OS:       context.WINDOWS,
-			Path:     &Path{Value: "/usr/local/bin"},
+			Path:     &Path{Value: testUsrLocalBin},
 			Expected: ``,
 		},
 	}
 
 	for _, tc := range cases {
-		useRuntime(t, &context.Runtime{Shell: tc.Shell, Home: "/Users/jan", OS: tc.OS, Path: &context.Path{"/usr/local/bin", "C:\\bin", "D:\\bin"}})
+		useRuntime(t, &context.Runtime{Shell: tc.Shell, Home: testHomeUnix, OS: tc.OS, Path: &context.Path{testUsrLocalBin, "C:\\bin", "D:\\bin"}})
 		assert.Equal(t, tc.Expected, tc.Path.string(), tc.Case)
 	}
 }
@@ -460,7 +460,7 @@ func TestPathWindowsMSYS2Normalization(t *testing.T) {
 	useRuntime(t, &context.Runtime{
 		Shell: BASH,
 		OS:    context.WINDOWS,
-		Home:  `C:\Users\trajano`,
+		Home:  testHomeWindows,
 		Path:  &context.Path{},
 	})
 
@@ -475,7 +475,7 @@ func TestPathWindowsWithoutMSYS2Normalization(t *testing.T) {
 	useRuntime(t, &context.Runtime{
 		Shell: BASH,
 		OS:    context.WINDOWS,
-		Home:  `C:\Users\trajano`,
+		Home:  testHomeWindows,
 		Path:  &context.Path{},
 	})
 

--- a/src/shell/test_constants_test.go
+++ b/src/shell/test_constants_test.go
@@ -1,0 +1,22 @@
+package shell
+
+const (
+	testAndroidHome          = "ANDROID_HOME"
+	testCaseHomeInTemplate   = "Home in template"
+	testCaseNoTemplate       = "No template"
+	testGitBangEchoWorld     = "!echo world"
+	testHelloEnvName         = "HELLO"
+	testHomeLinux            = "/home/trajano"
+	testHomeUnix             = "/Users/jan"
+	testHomeWindows          = `C:\Users\trajano`
+	testNameBarUpper         = "BAR"
+	testNameFooUpper         = "FOO"
+	testPathPwshWindows      = `$env:PATH = "C:\Users\jan\.tools\bin" + ';' + $env:PATH`
+	testShellUnknown         = "FOO"
+	testUsrLocalBin          = "/usr/local/bin"
+	testUsrLocalBinAndUsrBin = "/usr/local/bin\n/usr/bin"
+	testUsrLocalShare        = "/usr/local/share"
+	testUsrBin               = "/usr/bin"
+	testUsrShare             = "/usr/share"
+	testWindowsBins          = "C:\\bin\nD:\\bin"
+)

--- a/website/docs/setup/shell.mdx
+++ b/website/docs/setup/shell.mdx
@@ -84,33 +84,21 @@ exec fish
 <TabItem value="nu">
 
 :::caution
-aliae requires Nushell v0.78.0 or higher.
+aliae requires Nushell v0.104.0 or higher.
 :::
 
-Add the following line to the Nushell env file (`$nu.env-path`):
+Add the following line at the bottom of the Nushell config file (`$nu.config-path`):
 
 ```bash
 aliae init nu
 ```
 
-This saves the initialization script to `~/.aliae.nu`.
-Now, edit the Nushell config file (`$nu.config-path`) and add the following line at the bottom:
+This writes the initialization script to Nushell's vendor autoload directory
+(`$nu.data-dir/vendor/autoload/aliae.nu`). Nushell loads vendor autoload scripts
+after `config.nu`, so the freshly written script is picked up in the same session.
 
-```bash
-source ~/.aliae.nu
-```
-
-If you want to save the initialization script elsewhere, you can change the first line to something like this:
-
-```bash
-aliae init nu --print | save /mylocation/myscript.nu --force
-```
-
-And change the `source` line to:
-
-```bash
-source /mylocation/myscript.nu
-```
+If you previously sourced `~/.aliae.nu`, remove that line from `config.nu` and
+move any existing `aliae init nu` line out of `env.nu`.
 
 Once added, restart Nushell for the changes to take effect.
 


### PR DESCRIPTION
## What changed
- cherry-picked upstream commit a26806831598ed69835af8aeb63a5f4affb84af into this fork
- switched Nushell init output from ~/.aliae.nu to $nu.data-dir/vendor/autoload/aliae.nu
- added cached autoload-directory resolution and atomic write helpers with Windows retry handling
- updated the Nushell setup docs to match the new config.nu flow
- fixed the PR's Validate Code CI failure by aligning the Go tree with current lint expectations and excluding goconst from _test.go files only

## Why
This brings the upstream Nushell autoload integration into the fork so liae init nu can write a script that Nushell loads automatically in the same session, without a separate source ~/.aliae.nu step.

The follow-up CI fix keeps production goconst checks enabled while avoiding test-data churn unrelated to the Nushell feature.

## User impact
- Nushell now requires v0.104.0 or higher for this init flow
- existing source ~/.aliae.nu entries should be removed from config.nu
- any existing liae init nu line should live at the bottom of config.nu, not nv.nu

## Validation
- cd src && go fmt ./...
- cd src && go mod tidy
- cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run
- cd src && go install golang.org/x/tools/go/analysis/passes/fieldalignment/cmd/fieldalignment@latest
- cd src && "C:\Users\trajano\go"/bin/fieldalignment ./...
- cd src && go test ./...
- cd website && npm ci
- cd website && npm run build

## Notes
- The repo-wide markdownlint command still reports pre-existing MDX/markdown issues in unrelated docs files.
