### PR TITLE
fix(devcontainer): pin Go feature to a version satisfying go.mod

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
   },
   "features": {
     "ghcr.io/devcontainers/features/go:1": {
-      "version": "1.24.1"
+      "version": "1.26.5"
     },
     "ghcr.io/devcontainers/features/node:1": {
       "version": "20.9.0",


### PR DESCRIPTION
## Summary
- Bump the `.devcontainer/devcontainer.json` Go feature version from `1.24.1` to `1.26.5` so the devcontainer's Go toolchain satisfies `go.mod`'s `go 1.25.0` directive and matches the version CI (`.github/workflows/code.yml`, `gomod.yml`, `release.yml`) already pins.

Note: I checked whether the Node/npm feature versions also needed bumping, but `20.9.0`/`10.1.0` already match `website/package.json`'s `engines`/`volta` pins exactly, so those are left as-is to avoid introducing a new inconsistency.

## Testing
- Validated `.devcontainer/devcontainer.json` is still valid JSON
- Not rebuilt (devcontainer change, no local container runtime available here)