### PR TITLE
feat(config): add conditional includes

### DIFF
--- a/src/config/unmarshal.go
+++ b/src/config/unmarshal.go
@@ -88,7 +88,17 @@ func includeUnmarshaler(b []byte) ([]byte, error) {
 				return nil, fmt.Errorf("invalid %s directive: \n%s", f.Name, line)
 			}
 
-			folder := string(bytes.Join(parts[2:][0:], []byte(" ")))
+			pathParts, condition, hasCondition := splitIncludeCondition(parts)
+			if len(pathParts) < 3 {
+				return nil, fmt.Errorf("invalid %s directive: \n%s", f.Name, line)
+			}
+
+			if hasCondition && shell.If(condition).Ignore() {
+				s[i] = skippedIncludeLine(pathParts[0])
+				break
+			}
+
+			folder := string(bytes.Join(pathParts[2:], []byte(" ")))
 			path, err := validatePath(folder)
 			if err != nil {
 				return nil, err
@@ -106,7 +116,7 @@ func includeUnmarshaler(b []byte) ([]byte, error) {
 
 			indented := bytes.Join(splitted, newline)
 
-			result := parts[0][0:]
+			result := pathParts[0][0:]
 
 			switch string(result) {
 			case "-":
@@ -130,6 +140,37 @@ func includeUnmarshaler(b []byte) ([]byte, error) {
 	}
 
 	return includeUnmarshaler(data)
+}
+
+// splitIncludeCondition separates a trailing if="..." condition from an include directive.
+// The path remains whitespace-preserving so quoted paths containing spaces continue to work.
+func splitIncludeCondition(parts [][]byte) (pathParts [][]byte, condition string, ok bool) {
+	ifPrefix := []byte("if=")
+
+	for index := 2; index < len(parts); index++ {
+		if !bytes.HasPrefix(parts[index], ifPrefix) {
+			continue
+		}
+
+		raw := string(bytes.Join(parts[index:], []byte(" ")))
+		raw = strings.TrimPrefix(raw, "if=")
+		raw = strings.ReplaceAll(raw, `\"`, `"`)
+		return parts[:index], trimQuotes(raw), true
+	}
+
+	return parts, "", false
+}
+
+// skippedIncludeLine turns a skipped map include into a YAML null value and
+// removes a skipped list include entirely.
+func skippedIncludeLine(key []byte) []byte {
+	if string(key) == "-" {
+		return []byte{}
+	}
+
+	result := key[0:]
+	result = append(result, []byte(" null")...)
+	return result
 }
 
 func trimQuotes(s string) string {

--- a/src/config/unmarshal_test.go
+++ b/src/config/unmarshal_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -52,6 +54,79 @@ func TestRelativePath(t *testing.T) {
 		configPathCache = "https://example.com/config.yaml"
 		_, err := validatePath("path/to/nonex	istent/dir")
 		assert.Error(t, err)
+	})
+}
+
+func TestIncludeUnmarshalerCondition(t *testing.T) {
+	envFile := filepath.Join(t.TempDir(), "env.yaml")
+	assert.NoError(t, os.WriteFile(envFile, []byte("- name: TEST_ENV\n  value: test"), 0o600))
+
+	aliasDir := t.TempDir()
+	assert.NoError(t, os.WriteFile(filepath.Join(aliasDir, "aliases.yaml"), []byte("- name: g\n  value: git"), 0o600))
+
+	t.Run("true condition includes file", func(t *testing.T) {
+		input := fmt.Sprintf(`env: !include %q if="eq 1 1"`, envFile)
+
+		result, err := includeUnmarshaler([]byte(input))
+
+		assert.NoError(t, err)
+		assert.Contains(t, string(result), "TEST_ENV")
+	})
+
+	t.Run("false condition skips missing file without reading it", func(t *testing.T) {
+		input := `env: !include "does/not/exist.yaml" if="eq 1 2"`
+
+		result, err := includeUnmarshaler([]byte(input))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "env: null", string(result))
+	})
+
+	t.Run("condition supports quoted template arguments", func(t *testing.T) {
+		input := `env: !include "does/not/exist.yaml" if="hasCommand \"definitely-not-installed\""`
+
+		result, err := includeUnmarshaler([]byte(input))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "env: null", string(result))
+	})
+
+	t.Run("true condition includes directory contents", func(t *testing.T) {
+		input := fmt.Sprintf(`alias: !include_dir %q if="eq 1 1"`, aliasDir)
+
+		result, err := includeUnmarshaler([]byte(input))
+
+		assert.NoError(t, err)
+		assert.Contains(t, string(result), "name: g")
+	})
+
+	t.Run("false condition skips missing directory without reading it", func(t *testing.T) {
+		input := `alias: !include_dir "does/not/exist" if="eq 1 2"`
+
+		result, err := includeUnmarshaler([]byte(input))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "alias: null", string(result))
+	})
+
+	t.Run("false condition drops an inline list item", func(t *testing.T) {
+		input := "alias:\n  - !include \"does/not/exist.yaml\" if=\"eq 1 2\"\n  - name: g\n    value: git"
+
+		result, err := includeUnmarshaler([]byte(input))
+
+		assert.NoError(t, err)
+		assert.Equal(t, "alias:\n\n  - name: g\n    value: git", string(result))
+	})
+
+	t.Run("path with spaces is preserved", func(t *testing.T) {
+		spacedFile := filepath.Join(t.TempDir(), "my file.yaml")
+		assert.NoError(t, os.WriteFile(spacedFile, []byte("- name: spaced\n  value: true"), 0o600))
+		input := fmt.Sprintf(`alias: !include %q if="eq 1 1"`, spacedFile)
+
+		result, err := includeUnmarshaler([]byte(input))
+
+		assert.NoError(t, err)
+		assert.Contains(t, string(result), "name: spaced")
 	})
 }
 

--- a/website/docs/setup/include.mdx
+++ b/website/docs/setup/include.mdx
@@ -63,6 +63,21 @@ aliae:
   value: kubectl get --watch -f
 ```
 
+## Conditional include
+
+Both `!include` and `!include_dir` accept an optional trailing `if="..."`
+condition. The condition uses the same [template expression][if] syntax as an
+`if` field. When it evaluates to false, aliae skips the include without reading
+the target file or directory.
+
+```yaml title=".aliae.yaml"
+env: !include "{{ .Home }}/.aliae/kubernetes-env.yaml" if="hasCommand \"kubectl\""
+alias:
+  - !include "{{ .Home }}/.aliae/kubernetes.yaml" if="hasCommand \"kubectl\""
+  - name: g
+    value: git
+```
+
 ## Extends
 
 The `extends` key allows you to extend an existing configuration.
@@ -115,3 +130,4 @@ extends:
 - Extends nesting depth is limited to `10` levels.
 
 [templates]: templates.mdx
+[if]: if.mdx


### PR DESCRIPTION
## Summary

- Add optional trailing `if="..."` conditions to `!include` and `!include_dir` directives.
- Skip false-condition includes before validating or reading their file or directory targets.
- Preserve inline list includes, quoted template arguments, and paths with spaces.
- Document the syntax in the include guide.

## Upstream acknowledgement

Adapted from [Jan De Dobbeleer's upstream commit `2fad505`](https://github.com/JanDeDobbeleer/aliae/commit/2fad505f7999cd8a080516919b21e07b114785ce). Thank you to Jan De Dobbeleer for the implementation and test scenarios.

## Validation

- `cd src && go fmt ./...`
- `cd src && go mod tidy`
- `cd src && go test ./...`
- `cd src && go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest run`
- `cd src && fieldalignment ./...`
- `cd website && npm ci && npm run build`
- `npx --yes markdownlint-cli website/docs/setup/include.mdx`

The repository-wide Markdown lint command still reports existing failures in unrelated documentation; the changed include page passes on its own.
