### PR TITLE
docs: reframe upstream hostname support

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ focused on Git Bash support and fork-specific distribution.
   - Added `hasCommand` result caching and `hasCommandNoCache` for uncached checks.
   - Added `setArg` helper for shell-agnostic positional argument assignment.
   - Added `progress` template helper for OSC progress output and reset.
-  - Added `.ConfigPath` and `.ConfigDir` template variables.
+  - Refined configuration-location variables: `.ConfigPath` resolves the config file and
+    `.ConfigDir` resolves its directory.
   - Added `.Env` template map for environment variable access like `{{ .Env.DOTFILES }}`.
   - Added top-level `var` entries with precomputed values and `.Var` template map access.
   - Added `.ShellLike` template variable for bash/zsh/fish/tcsh/pwsh/powershell checks.
-  - Added `.Hostname` template variable to expose the system hostname.
   - Added `.WSL` template variable to indicate Windows Subsystem for Linux runtime.
 - PATH features:
   - Added `ifExists` option to include only existing path entries.

--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -43,11 +43,11 @@ with emphasis on Git Bash compatibility and fork-owned release/documentation flo
   - `hasCommand` caching with `hasCommandNoCache` for uncached checks.
   - `setArg` helper for shell-agnostic positional argument assignment.
   - `progress` helper for OSC progress output and reset.
-  - `.ConfigPath` and `.ConfigDir` template variables.
+  - Refined configuration-location variables: `.ConfigPath` resolves the config file and
+    `.ConfigDir` resolves its directory.
   - `.Env` template map for environment variable access like `{{ .Env.DOTFILES }}`.
   - Top-level `var` entries with precomputed values, available as `.Var.<Name>`.
   - `.ShellLike` template variable for bash/zsh/fish/tcsh/pwsh/powershell checks.
-  - `.Hostname` template variable that exposes the system hostname.
   - `.WSL` template variable that indicates Windows Subsystem for Linux runtime.
 - PATH capabilities:
   - `ifExists` option to include only existing path entries.


### PR DESCRIPTION
## Summary

- Remove `.Hostname` from the fork-only capability summaries now that upstream supports it.
- Reframe configuration-location support to describe the fork-specific `.ConfigPath` and `.ConfigDir` behavior accurately.

## Validation

- `npx --yes markdownlint-cli README.md website/docs/introduction.mdx`
- `cd website && npm ci && npm run build`
