### PR TITLE
feat(shell): add automatic WSL path conversion

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ focused on Git Bash support and fork-specific distribution.
   - Added `hasCommand` result caching and `hasCommandNoCache` for uncached checks.
   - Added `setArg` helper for shell-agnostic positional argument assignment.
   - Added `progress` template helper for OSC progress output and reset.
+  - Added automatic WSL `wslpath` conversion for Bash `path` and `cdpath` entries, plus a
+    `wslPath` template helper for other template values.
   - Refined configuration-location variables: `.ConfigPath` resolves the config file and
     `.ConfigDir` resolves its directory.
   - Added `.Env` template map for environment variable access like `{{ .Env.DOTFILES }}`.

--- a/src/context/os.go
+++ b/src/context/os.go
@@ -17,6 +17,15 @@ func isMSYS2Shell() bool {
 	return current.OS == WINDOWS && current.Shell == shellBash && os.Getenv("MSYSTEM") != ""
 }
 
+func isWSLPathShell() bool {
+	current := GetCurrent()
+	if current == nil {
+		return false
+	}
+
+	return current.WSL && current.Shell == shellBash
+}
+
 func PathDelimiter() string {
 	current := GetCurrent()
 	if current == nil {

--- a/src/context/path.go
+++ b/src/context/path.go
@@ -21,6 +21,15 @@ var runExternalCygpath = func(path string) (string, error) {
 	return strings.TrimSpace(string(output)), nil
 }
 
+var runWslpath = func(path string) (string, error) {
+	output, err := exec.Command("wslpath", "-a", path).Output()
+	if err != nil {
+		return "", err
+	}
+
+	return strings.TrimSpace(string(output)), nil
+}
+
 var cleanPathCache = map[string]string{}
 
 func getPath() *Path {
@@ -89,7 +98,9 @@ func cleanPath(path string) string {
 		return cached
 	}
 
-	if isMSYS2Shell() {
+	if isWSLPathShell() && isWindowsStylePath(path) {
+		path = WSLPath(path)
+	} else if isMSYS2Shell() {
 		switch cygpathMode() {
 		case CygpathExternal:
 			if normalized, err := runExternalCygpath(path); err == nil && normalized != "" {
@@ -103,6 +114,22 @@ func cleanPath(path string) string {
 	clean := strings.TrimRight(path, `/\`)
 	cleanPathCache[cacheKey] = clean
 	return clean
+}
+
+// WSLPath converts a Windows path through WSL's wslpath command. It preserves
+// the input when wslpath is unavailable or cannot convert the supplied path.
+func WSLPath(path string) string {
+	normalized, err := runWslpath(path)
+	if err != nil || normalized == "" {
+		return path
+	}
+
+	return normalized
+}
+
+// CleanPath normalizes a path for the current runtime.
+func CleanPath(path string) string {
+	return cleanPath(path)
 }
 
 func cygpathMode() string {
@@ -125,7 +152,7 @@ func cleanPathCacheKey(path string) string {
 		return "|:" + os.Getenv("MSYSTEM") + ":" + path
 	}
 
-	return current.OS + "|" + current.Shell + "|" + cygpathMode() + ":" + os.Getenv("MSYSTEM") + ":" + path
+	return fmt.Sprintf("%s|%s|%t|%s:%s:%s", current.OS, current.Shell, current.WSL, cygpathMode(), os.Getenv("MSYSTEM"), path)
 }
 
 func clearCleanPathCache() {
@@ -134,6 +161,14 @@ func clearCleanPathCache() {
 
 func isASCIIAlpha(value byte) bool {
 	return (value >= 'a' && value <= 'z') || (value >= 'A' && value <= 'Z')
+}
+
+func isWindowsStylePath(path string) bool {
+	if strings.HasPrefix(path, `\\`) {
+		return true
+	}
+
+	return len(path) >= 3 && isASCIIAlpha(path[0]) && path[1] == ':' && (path[2] == '\\' || path[2] == '/')
 }
 
 func splitPathEntries(paths string) []string {

--- a/src/context/path_test.go
+++ b/src/context/path_test.go
@@ -135,3 +135,34 @@ func TestCleanPathUsesInternalCygpathByDefault(t *testing.T) {
 
 	assert.Equal(t, "/c/Users/trajano/bin", cleanPath(`C:\Users\trajano\bin\`))
 }
+
+func TestCleanPathUsesWslpathForWSLBash(t *testing.T) {
+	SetCurrent(&Runtime{OS: LINUX, Shell: shellBash, WSL: true})
+	clearCleanPathCache()
+	t.Cleanup(clearCleanPathCache)
+
+	originalRunWslpath := runWslpath
+	t.Cleanup(func() { runWslpath = originalRunWslpath })
+
+	runWslpath = func(path string) (string, error) {
+		assert.Equal(t, `C:\Users\trajano\bin\`, path)
+		return "/mnt/c/Users/trajano/bin", nil
+	}
+
+	assert.Equal(t, "/mnt/c/Users/trajano/bin", cleanPath(`C:\Users\trajano\bin\`))
+}
+
+func TestCleanPathKeepsWindowsPathWhenWslpathFails(t *testing.T) {
+	SetCurrent(&Runtime{OS: LINUX, Shell: shellBash, WSL: true})
+	clearCleanPathCache()
+	t.Cleanup(clearCleanPathCache)
+
+	originalRunWslpath := runWslpath
+	t.Cleanup(func() { runWslpath = originalRunWslpath })
+
+	runWslpath = func(_ string) (string, error) {
+		return "", assert.AnError
+	}
+
+	assert.Equal(t, `C:\Users\trajano\bin`, cleanPath(`C:\Users\trajano\bin\`))
+}

--- a/src/shell/path.go
+++ b/src/shell/path.go
@@ -123,13 +123,24 @@ func pathEntryExists(entry string) bool {
 			resolved = windowsPath
 		}
 	}
+	if runtime != nil && runtime.WSL && runtime.Shell == BASH {
+		resolved = context.CleanPath(resolved)
+	}
 
 	return pathExists(resolved).exists
 }
 
 func normalizePathEntry(entry string) string {
 	runtime := currentRuntime()
-	if runtime == nil || runtime.OS != context.WINDOWS {
+	if runtime == nil {
+		return entry
+	}
+
+	if runtime.WSL && runtime.Shell == BASH {
+		return context.CleanPath(entry)
+	}
+
+	if runtime.OS != context.WINDOWS {
 		return entry
 	}
 

--- a/src/shell/path_test.go
+++ b/src/shell/path_test.go
@@ -184,6 +184,27 @@ export PATH="/usr/bin:$PATH"`,
 	}
 }
 
+func TestWSLBashConvertsPathAndCDPathEntries(t *testing.T) {
+	originalPath := os.Getenv("PATH")
+	dir := writeFakeWslpath(t, "/mnt/c/Users/jan/.tools/bin", 0)
+	assert.NoError(t, os.Setenv("PATH", dir+string(os.PathListSeparator)+originalPath))
+	t.Cleanup(func() { _ = os.Setenv("PATH", originalPath) })
+
+	useRuntime(t, &context.Runtime{
+		Shell:  BASH,
+		OS:     context.LINUX,
+		WSL:    true,
+		Path:   &context.Path{},
+		CDPath: &context.Path{},
+	})
+
+	path := &Path{Value: `C:\Users\jan\.tools\bin`}
+	assert.Equal(t, `export PATH="/mnt/c/Users/jan/.tools/bin:$PATH"`, path.string())
+
+	cdpath := &CDPath{Value: `C:\Users\jan\.tools\bin`}
+	assert.Equal(t, `export CDPATH="${CDPATH:+$CDPATH:}/mnt/c/Users/jan/.tools/bin"`, cdpath.string())
+}
+
 func TestPathRender(t *testing.T) {
 	cases := []struct {
 		Case           string

--- a/src/shell/template.go
+++ b/src/shell/template.go
@@ -185,6 +185,14 @@ func hasCommandNoCache(command string) bool {
 	return err == nil
 }
 
+// wslPath converts a Windows path to its WSL equivalent via the wslpath binary.
+// wslpath only exists inside WSL's interop layer, so its presence on PATH is
+// itself the WSL signal; path is returned unchanged when the binary isn't found
+// or fails to convert it.
+func wslPath(path string) string {
+	return context.WSLPath(path)
+}
+
 func fileExists(path string) bool {
 	info := pathExists(resolveFromHome(path))
 	return info.exists && !info.isDir

--- a/src/shell/template_registry.go
+++ b/src/shell/template_registry.go
@@ -18,6 +18,7 @@ var shellTemplateFuncProviders = []templatefunc.Provider{
 	templatefunc.Match(match),
 	templatefunc.HasCommand(hasCommand),
 	templatefunc.HasCommandNoCache(hasCommandNoCache),
+	templatefunc.WslPath(wslPath),
 	templatefunc.FileExists(fileExists),
 	templatefunc.DirExists(dirExists),
 	templatefunc.IsDir(isDir),

--- a/src/shell/template_test.go
+++ b/src/shell/template_test.go
@@ -1,6 +1,7 @@
 package shell
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -394,6 +395,59 @@ func TestHasCommandNoCacheBypassesCache(t *testing.T) {
 	foundNoCache, err := parse(`{{ hasCommandNoCache .Command }}`, struct{ Command string }{Command: commandName})
 	assert.NoError(t, err)
 	assert.Equal(t, "true", foundNoCache)
+}
+
+// writeFakeWslpath drops a script named "wslpath" (plus a Windows-executable
+// extension when needed) into a temporary directory. The script prints output
+// and exits with exitCode.
+func writeFakeWslpath(t *testing.T, output string, exitCode int) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		script := "@echo off\r\n"
+		if output != "" {
+			script += "echo " + output + "\r\n"
+		}
+		script += fmt.Sprintf("exit /b %d\r\n", exitCode)
+		assert.NoError(t, os.WriteFile(filepath.Join(dir, "wslpath.cmd"), []byte(script), 0o755))
+
+		return dir
+	}
+
+	script := "#!/bin/sh\n"
+	if output != "" {
+		script += "echo " + output + "\n"
+	}
+	script += fmt.Sprintf("exit %d\n", exitCode)
+	assert.NoError(t, os.WriteFile(filepath.Join(dir, "wslpath"), []byte(script), 0o755))
+
+	return dir
+}
+
+func TestWslPath(t *testing.T) {
+	originalPath := os.Getenv("PATH")
+	t.Cleanup(func() { _ = os.Setenv("PATH", originalPath) })
+
+	t.Run("wslpath not on PATH returns the input unchanged", func(t *testing.T) {
+		assert.NoError(t, os.Setenv("PATH", t.TempDir()))
+
+		assert.Equal(t, `C:\Documents\theme.omp.yml`, wslPath(`C:\Documents\theme.omp.yml`))
+	})
+
+	t.Run("wslpath converts the path", func(t *testing.T) {
+		dir := writeFakeWslpath(t, "/mnt/c/Documents/theme.omp.yml", 0)
+		assert.NoError(t, os.Setenv("PATH", dir+string(os.PathListSeparator)+originalPath))
+
+		assert.Equal(t, "/mnt/c/Documents/theme.omp.yml", wslPath(`C:\Documents\theme.omp.yml`))
+	})
+
+	t.Run("wslpath failure returns the input unchanged", func(t *testing.T) {
+		dir := writeFakeWslpath(t, "", 1)
+		assert.NoError(t, os.Setenv("PATH", dir+string(os.PathListSeparator)+originalPath))
+
+		assert.Equal(t, `C:\Documents\theme.omp.yml`, wslPath(`C:\Documents\theme.omp.yml`))
+	})
 }
 
 func TestFileExists(t *testing.T) {

--- a/src/shell/templatefunc/wsl_path.go
+++ b/src/shell/templatefunc/wsl_path.go
@@ -1,0 +1,5 @@
+package templatefunc
+
+func WslPath(fn any) Provider {
+	return New("wslPath", fn)
+}

--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -43,6 +43,8 @@ with emphasis on Git Bash compatibility and fork-owned release/documentation flo
   - `hasCommand` caching with `hasCommandNoCache` for uncached checks.
   - `setArg` helper for shell-agnostic positional argument assignment.
   - `progress` helper for OSC progress output and reset.
+  - Automatic WSL `wslpath` conversion for Bash `path` and `cdpath` entries, plus the `wslPath`
+    helper for other template values.
   - Refined configuration-location variables: `.ConfigPath` resolves the config file and
     `.ConfigDir` resolves its directory.
   - `.Env` template map for environment variable access like `{{ .Env.DOTFILES }}`.

--- a/website/docs/setup/templates.mdx
+++ b/website/docs/setup/templates.mdx
@@ -46,6 +46,7 @@ Out of the box you get the following functionality:
 | `match`          | `boolean` | match a shell name to one or multiple options              | `{{ match .Shell "zsh" "bash" }}`      |
 | `hasCommand`     | `boolean` | check if an executable exists (cached per command)         | `{{ hasCommand "oh-my-posh" }}`        |
 | `hasCommandNoCache` | `boolean` | check if an executable exists without using cache      | `{{ hasCommandNoCache "oh-my-posh" }}` |
+| `wslPath`        | `string`  | convert a Windows path to its WSL equivalent                | `{{ wslPath "C:\\Documents\\theme.omp.yml" }}`        |
 | `fileExists`     | `boolean` | check if a file exists relative to `.Home` by default      | `{{ fileExists ".cache/aliae" }}`      |
 | `dirExists`      | `boolean` | check if a directory exists relative to `.Home` by default | `{{ dirExists ".cache" }}`             |
 | `setArg`         | `string`  | emit shell-specific argument assignment statement | `{{ setArg "TARGET_HOST" 1 }}`          |
@@ -59,6 +60,10 @@ the cached result is reused instead of checking the filesystem again.
 
 `hasCommand` caches results per command during the current run.
 Use `hasCommandNoCache` when you need a fresh check after mutating `PATH` in the same run.
+
+`wslPath` uses WSL's `wslpath` binary to convert a Windows path. Outside WSL, or when conversion
+fails, it returns the original path unchanged, so it is safe in configurations shared across
+machines. In WSL Bash, path entries in `path` and `cdpath` are converted automatically as well.
 
 `var` entries are computed before other config sections render.
 You can use `.Var.<Name>` in other template values and `if` expressions.


### PR DESCRIPTION
## Summary
- automatically convert Windows-style drive and UNC entries in WSL Bash path and cdpath through wslpath -a
- preserve native Linux and relative entries, and retain the original input when wslpath is unavailable or conversion fails
- add the opt-in wslPath template helper for other template values
- document the behavior and cover conversion, fallback, PATH, and CDPATH rendering

## Validation
- Go format, module tidy, tests, golangci-lint, and fieldalignment
- Website build
- Markdown lint