### PR TITLE
fix(shell): convert WSL paths for all shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ focused on Git Bash support and fork-specific distribution.
   - Added `hasCommand` result caching and `hasCommandNoCache` for uncached checks.
   - Added `setArg` helper for shell-agnostic positional argument assignment.
   - Added `progress` template helper for OSC progress output and reset.
-  - Added automatic WSL `wslpath` conversion for Bash `path` and `cdpath` entries, plus a
+  - Added automatic WSL `wslpath` conversion for `path` and `cdpath` entries, plus a
     `wslPath` template helper for other template values.
   - Refined configuration-location variables: `.ConfigPath` resolves the config file and
     `.ConfigDir` resolves its directory.

--- a/src/context/os.go
+++ b/src/context/os.go
@@ -17,13 +17,13 @@ func isMSYS2Shell() bool {
 	return current.OS == WINDOWS && current.Shell == shellBash && os.Getenv("MSYSTEM") != ""
 }
 
-func isWSLPathShell() bool {
+func isWSLRuntime() bool {
 	current := GetCurrent()
 	if current == nil {
 		return false
 	}
 
-	return current.WSL && current.Shell == shellBash
+	return current.WSL
 }
 
 func PathDelimiter() string {

--- a/src/context/path.go
+++ b/src/context/path.go
@@ -98,7 +98,7 @@ func cleanPath(path string) string {
 		return cached
 	}
 
-	if isWSLPathShell() && isWindowsStylePath(path) {
+	if isWSLRuntime() && isWindowsStylePath(path) {
 		path = WSLPath(path)
 	} else if isMSYS2Shell() {
 		switch cygpathMode() {

--- a/src/context/path_test.go
+++ b/src/context/path_test.go
@@ -136,8 +136,8 @@ func TestCleanPathUsesInternalCygpathByDefault(t *testing.T) {
 	assert.Equal(t, "/c/Users/trajano/bin", cleanPath(`C:\Users\trajano\bin\`))
 }
 
-func TestCleanPathUsesWslpathForWSLBash(t *testing.T) {
-	SetCurrent(&Runtime{OS: LINUX, Shell: shellBash, WSL: true})
+func TestCleanPathUsesWslpathForWSL(t *testing.T) {
+	SetCurrent(&Runtime{OS: LINUX, Shell: shellZsh, WSL: true})
 	clearCleanPathCache()
 	t.Cleanup(clearCleanPathCache)
 
@@ -153,7 +153,7 @@ func TestCleanPathUsesWslpathForWSLBash(t *testing.T) {
 }
 
 func TestCleanPathKeepsWindowsPathWhenWslpathFails(t *testing.T) {
-	SetCurrent(&Runtime{OS: LINUX, Shell: shellBash, WSL: true})
+	SetCurrent(&Runtime{OS: LINUX, Shell: shellFish, WSL: true})
 	clearCleanPathCache()
 	t.Cleanup(clearCleanPathCache)
 

--- a/src/shell/path.go
+++ b/src/shell/path.go
@@ -123,7 +123,7 @@ func pathEntryExists(entry string) bool {
 			resolved = windowsPath
 		}
 	}
-	if runtime != nil && runtime.WSL && runtime.Shell == BASH {
+	if runtime != nil && runtime.WSL {
 		resolved = context.CleanPath(resolved)
 	}
 
@@ -136,7 +136,7 @@ func normalizePathEntry(entry string) string {
 		return entry
 	}
 
-	if runtime.WSL && runtime.Shell == BASH {
+	if runtime.WSL {
 		return context.CleanPath(entry)
 	}
 

--- a/src/shell/path_test.go
+++ b/src/shell/path_test.go
@@ -184,25 +184,49 @@ export PATH="/usr/bin:$PATH"`,
 	}
 }
 
-func TestWSLBashConvertsPathAndCDPathEntries(t *testing.T) {
+func TestWSLConvertsPathAndCDPathEntries(t *testing.T) {
 	originalPath := os.Getenv("PATH")
 	dir := writeFakeWslpath(t, "/mnt/c/Users/jan/.tools/bin", 0)
 	assert.NoError(t, os.Setenv("PATH", dir+string(os.PathListSeparator)+originalPath))
 	t.Cleanup(func() { _ = os.Setenv("PATH", originalPath) })
 
-	useRuntime(t, &context.Runtime{
-		Shell:  BASH,
-		OS:     context.LINUX,
-		WSL:    true,
-		Path:   &context.Path{},
-		CDPath: &context.Path{},
-	})
+	cases := []struct {
+		shell          string
+		expectedPath   string
+		expectedCDPath string
+	}{
+		{
+			shell:          BASH,
+			expectedPath:   `export PATH="/mnt/c/Users/jan/.tools/bin:$PATH"`,
+			expectedCDPath: `export CDPATH="${CDPATH:+$CDPATH:}/mnt/c/Users/jan/.tools/bin"`,
+		},
+		{
+			shell:          ZSH,
+			expectedPath:   `export PATH="/mnt/c/Users/jan/.tools/bin:$PATH"`,
+			expectedCDPath: `cdpath=( $cdpath /mnt/c/Users/jan/.tools/bin )`,
+		},
+		{
+			shell:          FISH,
+			expectedPath:   `fish_add_path /mnt/c/Users/jan/.tools/bin`,
+			expectedCDPath: `set -g cdpath $cdpath /mnt/c/Users/jan/.tools/bin`,
+		},
+	}
 
-	path := &Path{Value: `C:\Users\jan\.tools\bin`}
-	assert.Equal(t, `export PATH="/mnt/c/Users/jan/.tools/bin:$PATH"`, path.string())
+	for _, tc := range cases {
+		useRuntime(t, &context.Runtime{
+			Shell:  tc.shell,
+			OS:     context.LINUX,
+			WSL:    true,
+			Path:   &context.Path{},
+			CDPath: &context.Path{},
+		})
 
-	cdpath := &CDPath{Value: `C:\Users\jan\.tools\bin`}
-	assert.Equal(t, `export CDPATH="${CDPATH:+$CDPATH:}/mnt/c/Users/jan/.tools/bin"`, cdpath.string())
+		path := &Path{Value: `C:\Users\jan\.tools\bin`}
+		assert.Equal(t, tc.expectedPath, path.string(), tc.shell)
+
+		cdpath := &CDPath{Value: `C:\Users\jan\.tools\bin`}
+		assert.Equal(t, tc.expectedCDPath, cdpath.string(), tc.shell)
+	}
 }
 
 func TestPathRender(t *testing.T) {

--- a/website/docs/introduction.mdx
+++ b/website/docs/introduction.mdx
@@ -43,7 +43,7 @@ with emphasis on Git Bash compatibility and fork-owned release/documentation flo
   - `hasCommand` caching with `hasCommandNoCache` for uncached checks.
   - `setArg` helper for shell-agnostic positional argument assignment.
   - `progress` helper for OSC progress output and reset.
-  - Automatic WSL `wslpath` conversion for Bash `path` and `cdpath` entries, plus the `wslPath`
+  - Automatic WSL `wslpath` conversion for `path` and `cdpath` entries, plus the `wslPath`
     helper for other template values.
   - Refined configuration-location variables: `.ConfigPath` resolves the config file and
     `.ConfigDir` resolves its directory.

--- a/website/docs/setup/templates.mdx
+++ b/website/docs/setup/templates.mdx
@@ -63,7 +63,7 @@ Use `hasCommandNoCache` when you need a fresh check after mutating `PATH` in the
 
 `wslPath` uses WSL's `wslpath` binary to convert a Windows path. Outside WSL, or when conversion
 fails, it returns the original path unchanged, so it is safe in configurations shared across
-machines. In WSL Bash, path entries in `path` and `cdpath` are converted automatically as well.
+machines. In WSL, path entries in `path` and `cdpath` are converted automatically as well.
 
 `var` entries are computed before other config sections render.
 You can use `.Var.<Name>` in other template values and `if` expressions.


### PR DESCRIPTION
## Summary
- remove the Bash-only gate from automatic WSL Windows-path conversion
- apply conversion to all shells running in WSL before each shell formatter emits path or cdpath
- cover Bash, Zsh, and Fish path/CDPATH rendering and document the runtime-wide behavior

## Validation
- Go format, module tidy, tests, golangci-lint, and fieldalignment
- Website build
- Targeted Markdown lint passed
- Repository-wide Markdown lint remains blocked by existing violations outside this change